### PR TITLE
Kill Rserve debug processes as well

### DIFF
--- a/scripts/fresh_start.sh
+++ b/scripts/fresh_start.sh
@@ -14,5 +14,7 @@ fi
 cd ../..
 R CMD build rcloud.support && R CMD INSTALL rcloud.support_`sed -n 's/Version: *//p' rcloud.support/DESCRIPTION`.tar.gz
 killall -9 Rserve
+#Kill Rserve debug instances as well
+killall -9 Rserve.dbg
 rm -f conf/rcloud.auth
 ./conf/start -d


### PR DESCRIPTION
In some scenarios, Rcloud didn't exit cleanly and left a couple of debug processes. This can lead to socket bind errors on fresh_start.
