### PR TITLE
Minor fix for mhas crashing if an attribute exists but is undefined

### DIFF
--- a/htdocs/lib/js/dcplot/dcplot.js
+++ b/htdocs/lib/js/dcplot/dcplot.js
@@ -350,7 +350,7 @@ function dcplot(frame, groupname, definition) {
     // generalization of _.has
     function mhas(obj) {
         for(var i=1; i<arguments.length; ++i)
-            if(!_.has(obj, arguments[i]))
+            if(!_.has(obj, arguments[i]) || obj[arguments[i]] == undefined)
                 return false
         else obj = obj[arguments[i]];
         return true;


### PR DESCRIPTION
There was an object which had an attribute which existed but was set to undefined, and this loop was crashing.
