### PR TITLE
default fresh_start to no-debug, and correct the killall

### DIFF
--- a/scripts/fresh_start.sh
+++ b/scripts/fresh_start.sh
@@ -13,8 +13,6 @@ else
 fi
 cd ../..
 R CMD build rcloud.support && R CMD INSTALL rcloud.support_`sed -n 's/Version: *//p' rcloud.support/DESCRIPTION`.tar.gz || exit
-killall -9 Rserve
-#Kill Rserve debug instances as well
-killall -9 Rserve.dbg
+killall -9 RsrvSRV
 rm -f conf/rcloud.auth
-./conf/start -d
+./conf/start $*


### PR DESCRIPTION
@cscheid, @s-u:  I find the fresh_start script useful.  But apparently it's not good to run in debug mode, and I also noticed that the `killall` has gone stale (wrong process name).

Instead of just saying "fresh_start doesn't work", is this a reasonable fix?  It still allows running in debug mode by adding `-d` but it defaults to no debug.
