### PR TITLE
Fixed issue #383

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -253,7 +253,16 @@ RCloud.UI.init = function() {
         editor.post_comment($("#comment-entry-body").val());
         return false;
     });
-
+    
+    $("#comment-entry-body").keydown(function (e) {
+        if ((e.keyCode == 10 || e.keyCode == 13 || e.keyCode == 115 || e.keyCode == 19) && (e.ctrlKey || e.metaKey)) {
+            if(!Notebook.empty_for_github($("#comment-entry-body").val())) {
+                editor.post_comment($("#comment-entry-body").val());
+            }
+            return false;
+        }
+    });
+    
     $("#run-notebook").click(shell.run_notebook);
 
     RCloud.UI.scratchpad.init();


### PR DESCRIPTION
Fixed issue #383. Added the check for null before submitting the request on ctrl+enter.
Deleted the old branch with PR #721 as it got messed up while rebasing from develop.
Gordon: Looks like with your fix for rcloud.comment.post for handling errors(https://github.com/att/rcloud/commit/4d64b09b9e6d825fccec4ac1254f1b10bf5423e9 has broken the basic post comment functionality ). So once you fix that my commit for handling cmd/ctrl+enter and null check will work properly as am internally calling the same function for posting comments.
