### PR TITLE
Fixed issue #723

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -66,6 +66,8 @@ RCloud.UI.init = function() {
             else {
                 e.stopPropagation();
                 e.preventDefault();
+                e.originalEvent.dataTransfer.effectAllowed= 'none';
+                e.originalEvent.dataTransfer.dropEffect= 'none';
             }
         }
     });


### PR DESCRIPTION
1>This is a fix for the bug where multiple assets drop is rejected(no overlay for drop and files dropped are ignored) but there is no cursor change indication as of now.
2>Fixed the issue(reopen) reported by Arko that due to fix on #731(ignore drops that aren't files) the asset drag check for historical notebooks got broke and user gets navigated to the file on drop.

Still not successful in getting the + ikon on the asset area. Somehow managed to get the + ikon using
 e.dataTransfer.effectAllowed="copy"; on dragover but not able to control it. The Will continue to find some solution for this but I think you can go ahead and review it for the fix towards above two issues. 
