### PR TITLE
install rcloud.packages/ the way internal/ is already

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,12 +28,15 @@ done
 R CMD build rcloud.client && RCS_SILENCE_LOADCHECK=TRUE R CMD INSTALL rcloud.client_`sed -n 's/Version: *//p' rcloud.client/DESCRIPTION`.tar.gz || exit 1
 R CMD build rcloud.support && RCS_SILENCE_LOADCHECK=TRUE R CMD INSTALL rcloud.support_`sed -n 's/Version: *//p' rcloud.support/DESCRIPTION`.tar.gz || exit 1
 
-# build internal packages (not in git)
-if [ -e internal ]; then
-    for pkg in `ls internal/*/DESCRIPTION 2>/dev/null | sed -e 's:internal/::' -e 's:/DESCRIPTION::'`; do
-	(cd internal && R CMD build $pkg && R CMD INSTALL `sed -n 's/Package: *//p' $pkg/DESCRIPTION`_`sed -n 's/Version: *//p' $pkg/DESCRIPTION`.tar.gz)
-    done
-fi
+# build internal packages (not in git) & rcloud.packages
+for dir in internal rcloud.packages; do
+    if [ -e $dir ]; then
+        for pkg in `ls $dir/*/DESCRIPTION 2>/dev/null | sed -e s:$dir/:: -e 's:/DESCRIPTION::'`; do
+            echo $pkg
+	    (cd $dir  && R CMD build $pkg && R CMD INSTALL `sed -n 's/Package: *//p' $pkg/DESCRIPTION`_`sed -n 's/Version: *//p' $pkg/DESCRIPTION`.tar.gz)
+        done
+    fi
+done
 
 if [ -e ".git" ]; then
 # update branch/revision info


### PR DESCRIPTION
adding a loop over `internal rcloud.packages` to build.sh
had to remove some single quotes to do it.
@s-u, is this acceptable?

fixes #749
