### PR TITLE
Moved load_module_package to authenticated ocaps

### DIFF
--- a/rcloud.support/R/ocaps.R
+++ b/rcloud.support/R/ocaps.R
@@ -57,9 +57,6 @@ unauthenticated.ocaps <- function()
 
       get_users = make.oc(rcloud.get.users),
 
-      # externally used ocaps
-      load_module_package = make.oc(rcloud.load.module.package),
-
       # javascript.R
       setup_js_installer = make.oc(rcloud.setup.js.installer),
 
@@ -133,6 +130,9 @@ authenticated.ocaps <- function()
       # call_fastrweb_notebook...
       call_fastrweb_notebook = make.oc(rcloud.call.FastRWeb.notebook),
 
+      # externally used ocaps
+      load_module_package = make.oc(rcloud.load.module.package),
+      
       # file upload ocaps
       file_upload = list(
         create = make.oc(rcloud.upload.create.file),


### PR DESCRIPTION
Quick request - the load_module_package is mostly used in authenticated scenarios for additional applications. This would be particularly useful for some internal application(hint - go and fish) which require authentication. This is a little critical so it would be very helpful if you could include this in this release.

Thanks,
SMS
