### PR TITLE
fixes #704 : fork a notebook with ctrl+enter while renaming

### DIFF
--- a/htdocs/js/ui/notebook_title.js
+++ b/htdocs/js/ui/notebook_title.js
@@ -16,7 +16,7 @@ RCloud.UI.notebook_title = (function() {
         range.setEnd(el.firstChild, text.length);
         return range;
     }
-    var fork = function(forked_gist_name) {
+    var ctrl_cmd = function(forked_gist_name) {
         var is_mine = shell.notebook.controller.is_mine();
         var gistname = shell.gistname();
         var version = shell.version();
@@ -28,7 +28,7 @@ RCloud.UI.notebook_title = (function() {
     var editable_opts = {
         change: rename_current_notebook,
         select: select,
-        fork:fork,
+        ctrl_cmd:ctrl_cmd,
         validate: function(name) { return editor.validate_name(name); }
     };
 

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -393,20 +393,20 @@ ui_utils.editable = function(elem$, command) {
             var entr_key = (e.keyCode === 13);
             if (entr_key && (e.ctrlKey || e.metaKey)) {
                 e.preventDefault();
-                var result = elem$.text();
-                result = decode(result);
+                var txt = elem$.text();
+                txt = decode(txt);
                 elem$.blur();
-                options().fork(result);
+                options().ctrl_cmd(txt);
             }
             else if((command.allow_multiline && (entr_key && (e.ctrlKey || e.metaKey))) || (entr_key && !command.allow_multiline)) {
                 e.preventDefault();
-                var result = elem$.text();
-                result = decode(result);
-                if(options().validate(result)) {
+                var txt = elem$.text();
+                txt = decode(txt);
+                if(options().validate(txt)) {
                     options().__active = false;
                     elem$.off('blur'); // don't cancel!
                     elem$.blur();
-                    options().change(result);
+                    options().change(txt);
                 } else {
                     return false; // don't let CR through!
                 }


### PR DESCRIPTION
removed extra key compariosons
