### PR TITLE
This Fixes #818 - ctrl/cmd-S save

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -114,7 +114,7 @@ RCloud.UI.init = function() {
     document.addEventListener("keydown", function(e) {
         if (e.keyCode == 83 && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
-            $('#save-notebook').click();
+            shell.save_notebook();
         }
     });
 };


### PR DESCRIPTION
prevent default ctrl/cmd+s on browser and internally hit save icon
