### PR TITLE
This Fixes #788

### DIFF
--- a/htdocs/js/ui/comments_frame.js
+++ b/htdocs/js/ui/comments_frame.js
@@ -79,7 +79,7 @@ RCloud.UI.comments_frame = (function() {
             var scroll_height = "";
             $("#comment-submit").click(function() {
                 if(!Notebook.empty_for_github(comment.val())) {
-                    that.post_comment(comment.val());
+                    that.post_comment(_.escape(comment.val()));
                     comment.height("41px");
                 }
                 return false;
@@ -88,7 +88,7 @@ RCloud.UI.comments_frame = (function() {
             comment.keydown(function (e) {
                 if (e.keyCode == 13 && (e.ctrlKey || e.metaKey)) {
                     if(!Notebook.empty_for_github(comment.val())) {
-                        that.post_comment(comment.val());
+                        that.post_comment(_.escape(comment.val()));
                         comment.height("41px");
                         count = 0;
                         scroll_height = "";


### PR DESCRIPTION
Used _.escape(string)  from underscore.js to escape a string for insertion into HTML, replacing &, <, >, ", `, and ' characters. 
@gordonwoodhull This is fixed please review.
