### PR TITLE
Fix for NumericInput height

### DIFF
--- a/htdocs/mini.html
+++ b/htdocs/mini.html
@@ -6,7 +6,7 @@
     <script src="/lib/js/require-common.js"></script>
     <script type="text/javascript" data-main="/lib/js/require-mini.js" src="/lib/js/require.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="/css/bootstrap.css"/>
+    <link rel="stylesheet" type="text/css" href="../../shared.R/bootstrap/css/bootstrap.min.css"/>
     <link rel="stylesheet" type="text/css" href="/css/dc.css"/>
   </head>
   <body>


### PR DESCRIPTION
Issue was due to conflict in bootstrap.css, so sourcing it from shared.R
