### PR TITLE
This Fixes #951 : loading a notebook after fork to change username

### DIFF
--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -199,7 +199,7 @@ Notebook.create_controller = function(model)
 
     function apply_changes_and_load(changes, gistname) {
         return changes.length ?
-            update_notebook(changes, gistname) :
+            update_notebook(changes, gistname).then(result.load_notebook(gistname, null)) :
             result.load_notebook(gistname, null); // do a load - we need to refresh
     }
 


### PR DESCRIPTION
loading a notebook after forking and loading history version changes, to change username in notebook title.
