### PR TITLE
Fixed mkdist to latest with the current folders Fixes #1005

### DIFF
--- a/packages/githubgist/DESCRIPTION
+++ b/packages/githubgist/DESCRIPTION
@@ -4,5 +4,6 @@ Version: 1.0-0
 Author: Simon Urbanek <urbanek@research.att.com>
 Maintainer: Simon Urbanek <urbanek@research.att.com>
 Description: Gist interface to GitHub
+Depends: github
 Imports: gist
 License: MIT

--- a/rcloud.support/DESCRIPTION
+++ b/rcloud.support/DESCRIPTION
@@ -5,7 +5,7 @@ Author: Carlos Scheidegger <cscheid@research.att.com>, Simon Urbanek <urbanek@re
 Maintainer: Carlos Scheidegger <cscheid@research.att.com>
 Description: It's used by RCloud internally.
 Depends: base64enc, rjson, parallel
-Imports: uuid, RCurl, unixtools, Rserve (>= 1.8-1), rediscc (>= 0.1-1), jsonlite, knitr, markdown, png, Cairo, httr, gist, mime
+Imports: uuid, RCurl, unixtools, Rserve (>= 1.8-1), rediscc (>= 0.1-1), jsonlite, knitr, markdown, png, Cairo, httr, mime
 NOTE: --- packages that are not on CRAN/RForge.net *must* be in Suggests! ---
-Suggests: FastRWeb, RSclient, rcloud.client
+Suggests: FastRWeb, RSclient, rcloud.client, gist
 License: MIT

--- a/scripts/bootstrapRCloud.sh
+++ b/scripts/bootstrapRCloud.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 WD=`pwd`
-if [ ! -e "$WD/../pkg.repos/src/contrib/PACKAGES" ]; then
+if [ ! -e "$WD/R-Package-Repository/src/contrib/PACKAGES" ]; then
     echo '' 2>&1
     if [ -e "$WD/rcloud.support/DESCRIPTION" ]; then
 	mkdir -p "$WD/packages/src/contrib" 2>/dev/null
@@ -25,7 +25,7 @@ if [ "x$ok" != "xOK" ]; then
 fi
 
 export RCS_SILENCE_LOADCHECK=TRUE
-echo 'cat(sprintf("\n Using %s, installing packages...\n", R.version.string)); url="file://'"$WD"'/../pkg.repos/"; a=rownames(available.packages(paste0(url,"/src/contrib"))); install.packages(a,,url,type="source")' | R --slave --vanilla
+echo 'cat(sprintf("\n Using %s, installing packages...\n", R.version.string)); url="file://'"$WD"'/R-Package-Repository/"; a=rownames(available.packages(paste0(url,"/src/contrib"))); install.packages(a,,url,type="source")' | R --slave --vanilla
 
 ok=`echo 'library(rcloud.support);library(rcloud.client);library(Cairo);library(rjson);cat("OK\n")' | R --slave --vanilla`
 if [ "x$ok" != "xOK" ]; then
@@ -35,6 +35,9 @@ if [ "x$ok" != "xOK" ]; then
     echo '' 2>&1
     exit 1
 fi
+
+
+
 
 echo ''
 echo '============================================================================'


### PR DESCRIPTION
Included mathjax pull in htdocs for distribution tar ball
Renamed bootstrapR.sh We are bootstrapping RCloud not R. I have another script called bootstrapR to bootstrap "R"
moved 'gist' in rcloud.support from depends to suggests
Added github as depends in githubgist
Currently deleting gitgist and guitar only because boost is fairly difficult to build on target systems
