### PR TITLE
This Fixes #766,#1062: search results from deleted or private notebooks

### DIFF
--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -305,6 +305,14 @@ update.solr <- function(notebook, starcount){
   }
 }
 
+delete.solr.notebook <-function(id) {
+  url <- getConf("solr.url")
+  if (is.null(url)) stop("solr is not enabled")
+  solr.url <- paste0(url,"/update?stream.body=<delete><query>id:",id,"</query></delete>&commit=true")
+  solr.res <- getURL(solr.url, .encoding = 'utf-8', .mapUnicode=FALSE)
+  return(solr.res)
+}
+
 rcloud.search <-function(query, sortby, orderby, start, pagesize) {
   url <- getConf("solr.url")
   if (is.null(url)) stop("solr is not enabled")
@@ -457,8 +465,16 @@ rcloud.is.notebook.visible <- function(id) {
   visibility
 }
 
-rcloud.set.notebook.visibility <- function(id, value)
+rcloud.set.notebook.visibility <- function(id, value) {
   rcloud.set.notebook.property(id, "visible", value != 0);
+  if(value){
+     nb <- rcloud.get.notebook(id)
+     star.count <- rcloud.notebook.star.count(id)
+     update.solr(nb, star.count)
+  } else {
+     delete.solr.notebook(id)
+  }
+}
 
 rcloud.port.notebooks <- function(url, books, prefix) {
   foreign.ctx <- create.github.context(url)
@@ -615,8 +631,10 @@ rcloud.config.get.recent.notebooks <- function() {
 rcloud.config.set.recent.notebook <- function(id, date)
   rcs.set(usr.key(user=.session$username, notebook="system", "config", "recent", id), date)
 
-rcloud.config.clear.recent.notebook <- function(id)
+rcloud.config.clear.recent.notebook <- function(id) {
   rcs.rm(usr.key(user=.session$username, notebook="system", "config", "recent", id))
+  delete.solr.notebook(id)
+}
 
 rcloud.config.get.user.option <- function(key) {
   if(length(key)>1) {


### PR DESCRIPTION
@sneha-bharti can you please test this out thoroughly on your solr instance. My solr is unfriendly sometimes.

@gordonwoodhull The delete issue which I was telling earlier is kind of solved with our current version of solr as now am using the xml syntax for delete query. Earlier I was using the json format of query. Both are allowed. I found using xml mode(opt 2)is consistent and always deletes.

I have spent 90 % time in testing this one and 10% in code.:)

1>The json format of curl req : 
```
http://myURL/update?commit=true" -H 'Content-type:application/json' -d '{"delete": {"id":"1730887464"}}
```
2>The xml format of request(using in this commit) to solr : 
```
http://localhost:8983/solr/update?stream.body=<delete><query>id:1332922</query></delete>&commit=true
```