### PR TITLE
This Fixes #1054: allow right-clicking on search links to open or copy URL

### DIFF
--- a/htdocs/js/ui/search.js
+++ b/htdocs/js/ui/search.js
@@ -203,7 +203,7 @@ return {
                         if(parts_table !== "") {
                             if(nooflines > 10) {
                                 parts_table = "<div><div style=\"height:150px;overflow: hidden;\" id='"+i+"'><table style='width: 100%'>" + parts_table + "</table></div>" +
-                                    "<div style=\"position: relative;\"><a href=\'"+url+"'\" id='"+togid+"' onclick=\"RCloud.UI.search.toggle("+i+",'"+togid+"');\" style=\"color:orange\">Show me more...</a></div></div>";
+                                    "<div style=\"position: relative;\"><a href=\"#\" id='"+togid+"' onclick=\"RCloud.UI.search.toggle("+i+",'"+togid+"');\" style=\"color:orange\">Show me more...</a></div></div>";
                             } else {
                                 parts_table = "<div><div id='"+i+"'><table style='width: 100%'>" + parts_table + "</table></div></div>";
                             }


### PR DESCRIPTION
Issue #1054 is fixed with this PR.
Added hyperlink to <a href=  so that users can open the notebook in another tab.
The current functionality remains intact in which on click of the notebook opens the notebook in the same tab without reloading.
