### PR TITLE
This Fixes #1053 : Deleted notebook is undefined

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1059,7 +1059,7 @@ var editor = function () {
             if(node.user===username_) {
                 var remove = ui_utils.fa_button('icon-remove', 'remove', 'remove', icon_style, true);
                 remove.click(function(e) {
-                   var yn = confirm("Do you want to remove '"+node.full_name+"'?");
+                   var yn = confirm("Do you want to remove '"+node.name+"'?");
                    if (yn) {
                        e.stopPropagation();
                        e.preventDefault();


### PR DESCRIPTION
Using the correct attribute, now showing the name of the notebook being deleted.

![undefined notebook](https://cloud.githubusercontent.com/assets/1859165/5102140/bb52f2ae-6feb-11e4-846b-d44a57c29e7e.png)
