### PR TITLE
initialize tmpfile name in call.FastRWeb.notebook instead

### DIFF
--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -201,6 +201,8 @@ rcloud.unauthenticated.call.FastRWeb.notebook <- function(id, version = NULL, ar
 }
 
 rcloud.call.FastRWeb.notebook <- function(id, version = NULL, args = NULL) {
+  set.seed(Sys.getpid()) # we want different seeds so we get different file names
+  .GlobalEnv$tmpfile <- paste('tmp-',paste(sprintf('%x',as.integer(runif(4)*65536)),collapse=''),'.tmp',sep='')
   result <- rcloud.call.notebook(id, version, NULL)
   if (is.function(result)) {
     require(FastRWeb)

--- a/rcloud.support/R/session.R
+++ b/rcloud.support/R/session.R
@@ -138,8 +138,6 @@ session.markdown.eval <- function(command, language, silent) {
 
 ## WS init
 rcloud.session.init <- function(...) {
-  set.seed(Sys.getpid()) # we want different seeds so we get different file names
-  .GlobalEnv$tmpfile <- paste('tmp-',paste(sprintf('%x',as.integer(runif(4)*65536)),collapse=''),'.tmp',sep='')
   start.rcloud(...)
   rcloud.reset.session()
 


### PR DESCRIPTION
fixes #1067 

I verified that it hides the tmpname, however, I don't know how tmpname is used, so I can't test that it hasn't broken that.  @s-u, please verify or tell me a notebook to test on.