### PR TITLE
Adds support for an authenticated redis instance

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -173,9 +173,27 @@ which will re-fetch and install all packages.
 #### Redis
 
 It is strongly recommended to use Redis as the back-end for key/value
-storage in RCloud. Install Redis server (in Debian/Ubuntu
-`sudo apt-get install redis-server`) and add `rcs.engine: redis` to
-the `rcloud.conf` configuration file.
+storage in RCloud. To enable it, install Redis on the RCloud machine
+(`sudo apt-get install redis-server` in Debian/Ubuntu) and install `rediscc`
+package in R:
+
+    install.packages("rediscc",,"http://rforge.net")
+
+The `conf/rcloud.conf` file contains configuration for rcloud, including redis
+configurations. In order to enable redis as your store, you must add
+
+    rcs.engine: redis
+
+Other configurations include `rcs.redis.host` 
+for redis instances (default `127.0.0.1:6379`), and `rcs.redis.password` for
+authentication (default no authentication).
+
+    rcs.redis.host: HOST:PORT
+    rcs.redis.password: PASSWORD
+
+If you are converting an existing instance, There is a migration
+script `scripts/migrate2redis.sh` which migrates from flat file RCS to
+Redis-based RCS if needed.
 
 Note: the default up until RCloud 1.0 is file-based RCS back-end which
 is limited and deprecated and thus the default may become Redis in

--- a/doc/README.md
+++ b/doc/README.md
@@ -41,19 +41,8 @@ issues in multi-user setup for several reasons: permissions may not
 allow multiple users to read/write the same file and operations may
 not be atomic if multiple users try to modify the same file. RCloud
 provides an alternative back-end which is highly recommended over the
-default, but requires [Redis](http://redis.io/) server. To enable it,
-install Redis on the RCloud machine
-(`sudo apt-get install redis-server` in Debian/Ubuntu) and add
-
-    rcs.engine: redis
-
-to `rcloud.conf`. Finally, you have to install `rediscc` package in R:
-
-    install.packages("rediscc",,"http://rforge.net")
-
-If you are converting an existing instance, There is a migration
-script `scripts/migrate2redis.sh` which migrates from flat file RCS to
-Redis-based RCS if needed.
+default, but requires [Redis](http://redis.io/) server. Please refer to
+the installation guide for specific installation instructions.
 
 
 ## Multi-user setup

--- a/rcloud.support/DESCRIPTION
+++ b/rcloud.support/DESCRIPTION
@@ -5,7 +5,7 @@ Author: Carlos Scheidegger <cscheid@research.att.com>, Simon Urbanek <urbanek@re
 Maintainer: Carlos Scheidegger <cscheid@research.att.com>
 Description: It's used by RCloud internally.
 Depends: base64enc, rjson, parallel
-Imports: uuid, RCurl, unixtools, Rserve (>= 1.8-1), rediscc (>= 0.1-1), jsonlite, knitr, markdown, png, Cairo, httr, gist, mime
+Imports: uuid, RCurl, unixtools, Rserve (>= 1.8-1), rediscc (>= 0.1-2), jsonlite, knitr, markdown, png, Cairo, httr, gist, mime
 NOTE: --- packages that are not on CRAN/RForge.net *must* be in Suggests! ---
 Suggests: FastRWeb, RSclient, rcloud.client
 License: MIT

--- a/rcloud.support/R/rcs.redis.R
+++ b/rcloud.support/R/rcs.redis.R
@@ -1,4 +1,4 @@
-rcs.redis <- function(host=NULL) {
+rcs.redis <- function(host=NULL, password=NULL) {
   require(rediscc)
   if (!is.null(host)) {
     hp <- strsplit(as.character(host), ':', TRUE)[[1]]
@@ -8,7 +8,10 @@ rcs.redis <- function(host=NULL) {
     host <- "localhost"
     port <- 6379L
   }
-  structure(list(host=host, port=port, handle=redis.connect(host, port, 3, TRUE, TRUE)), class="RCSredis")
+  connection = redis.connect(host, port, 3, TRUE, TRUE)
+  if(!is.null(password)) redis.auth(connection, password)
+
+  structure(list(host=host, port=port, handle=connection), class="RCSredis")
 }
 
 rcs.close.RCSredis <- function(engine=.session$rcs.engine)

--- a/rcloud.support/R/setup.R
+++ b/rcloud.support/R/setup.R
@@ -228,7 +228,7 @@ configure.rcloud <- function (mode=c("startup", "script")) {
 ## create rcs back-end according to teh config files
 session.init.rcs <- function() {
     if (isTRUE(getConf("rcs.engine") == "redis")) {
-        .session$rcs.engine <- rcs.redis(getConf("rcs.redis.host"))
+        .session$rcs.engine <- rcs.redis(getConf("rcs.redis.host"), getConf("rcs.redis.password"))
         if (is.null(.session$rcs.engine$handle)) stop("ERROR: cannot connect to redis host `",getConf("rcs.redis.host"),"', aborting")
     } else {
         if (nzConf("exec.auth") && identical(getConf("exec.match.user"), "login"))


### PR DESCRIPTION
Submitted an issue and pull request against `rediscc` (s-u/rediscc#4), the underlying
redis library used in RCloud. This was changed and repushed as version
0.1-2.

Now users can specify a property in rcloud.conf for the password to
their redis instance.

These changes and a few more have been documented in the INSTALL.md and
README.md.