### PR TITLE
Update bootstrapR.sh

### DIFF
--- a/scripts/bootstrapR.sh
+++ b/scripts/bootstrapR.sh
@@ -111,7 +111,7 @@ RCMD
   )
   cran = available.packages(contrib.url(c('http://r.research.att.com/', 'http://rforge.net'), type = 'source'), type = 'source')
   local = available.packages(contrib.url('file://$RCREPO', type = 'source'), type = 'source')
-  repos = c('http://rforge.net', 'http://r.research.att.com', 'file://$RCREPO')
+  repos = c('file://$RCREPO', 'http://rforge.net', 'http://r.research.att.com')
   
   rcloud_deps = unique(unlist(tools:::package_dependencies(pkg, local, 'all')))
   deps_of_rcloud_deps = unique(unlist(tools:::package_dependencies(rcloud_deps, rbind(cran, local), recursive = TRUE)))

--- a/scripts/bootstrapR.sh
+++ b/scripts/bootstrapR.sh
@@ -111,23 +111,17 @@ RCMD
   )
   cran = available.packages(contrib.url(c('http://r.research.att.com/', 'http://rforge.net'), type = 'source'), type = 'source')
   local = available.packages(contrib.url('file://$RCREPO', type = 'source'), type = 'source')
+  repos = c('http://rforge.net', 'http://r.research.att.com', 'file://$RCREPO')
+  
+  rcloud_deps = unique(unlist(tools:::package_dependencies(pkg, local, 'all')))
+  deps_of_rcloud_deps = unique(unlist(tools:::package_dependencies(rcloud_deps, rbind(cran, local), recursive = TRUE)))
+  deps = unique(c(rcloud_deps, deps_of_rcloud_deps))
+  
+  locally_installed_packages = rownames(installed.packages(, 'high'))
+  packages_needing_installation = deps[!(deps %in% locally_installed_packages)]
+  print(packages_needing_installation)
 
-  stage1 = unique(
-    unlist(tools:::package_dependencies(pkg, local, 'all'))
-  )
-  print(stage1)
-
-  stage2 = unique(
-    c(
-      stage1,
-      unlist(tools:::package_dependencies(stage1, rbind(cran,local), , TRUE))
-    )
-  )
-  rec = rownames(installed.packages(, 'high'))
-  stage2 = stage2[!(stage2 %in% rec)]
-  print(stage2)
-
-  download.packages(stage2, '$DISTREP/src/contrib', , c('http://rforge.net', 'http://r.research.att.com', 'file://$RCREPO'), type = 'source')
+  download.packages(packages_needing_installation, '$DISTREP/src/contrib', repos = repos, type = 'source')
   tools:::write_PACKAGES('$DISTREP/src/contrib')
 RCMD
 
@@ -139,8 +133,8 @@ else
     "$RBIN" --slave --vanilla <<RCMD
   cat(sprintf("\n Using %s, installing packages...\n", R.version.string))
   url = "file://'"$DISTREP/"'"
-  a = rownames(available.packages(paste0(url, "/src/contrib")))
-  install.packages(a, , url, type = "source")
+  packages = rownames(available.packages(paste0(url, "/src/contrib")))
+  install.packages(packages, repos = url, type = "source")
 RCMD
 fi
 

--- a/scripts/bootstrapR.sh
+++ b/scripts/bootstrapR.sh
@@ -81,9 +81,14 @@ if [ ! -e "$DISTREP/src/contrib/PACKAGES" -o -n "$mkdist" ]; then
         echo " --- Installing RCloud packages and dependencies in R"
         "$RBIN" --vanilla --slave --no-save <<RCMD || exit 1
   install.packages(
-    unique(gsub('_.*','',basename(Sys.glob('$RCREPO/src/contrib/*.tar.gz')))),
-    repos=c('file://$RCREPO','http://r.research.att.com','http://rforge.net'),
-    type='source'
+    # Find all tar'ed packages and extract the package name from them
+    unique(
+      gsub(
+        '_.*', '', basename(Sys.glob('$RCREPO/src/contrib/*.tar.gz'))
+      )
+    ),
+    repos = c('file://$RCREPO', 'http://r.research.att.com', 'http://rforge.net'),
+    type = 'source'
   )
 RCMD
 
@@ -96,22 +101,33 @@ RCMD
         cp -p "$RCREPO/src/contrib/"*.tar.gz "$DISTREP/src/contrib/"
 
         "$RBIN" --vanilla --slave <<RCMD || exit 1
-  options(warn=2)
-  pkg<-unique(gsub('_.*','',basename(Sys.glob('$RCREPO/src/contrib/*.tar.gz'))))
-  cran=available.packages(
-      contrib.url(c('http://r.research.att.com/','http://rforge.net'),type='source'),type='source'
-  )
-  local=available.packages(contrib.url('file://$RCREPO',type='source'),type='source')
+  options(warn = 2)
 
-  stage1=unique(unlist(tools:::package_dependencies(pkg,local,'all')))
+  # Find all tar'ed packages and extract the package name from them
+  pkg <- unique(
+    gsub(
+      '_.*', '', basename(Sys.glob('$RCREPO/src/contrib/*.tar.gz'))
+    )
+  )
+  cran = available.packages(contrib.url(c('http://r.research.att.com/', 'http://rforge.net'), type = 'source'), type = 'source')
+  local = available.packages(contrib.url('file://$RCREPO', type = 'source'), type = 'source')
+
+  stage1 = unique(
+    unlist(tools:::package_dependencies(pkg, local, 'all'))
+  )
   print(stage1)
 
-  stage2=unique(c(stage1,unlist(tools:::package_dependencies(stage1,rbind(cran,local),,TRUE))))
-  rec=rownames(installed.packages(,'high'))
-  stage2=stage2[!(stage2 %in% rec)]
+  stage2 = unique(
+    c(
+      stage1,
+      unlist(tools:::package_dependencies(stage1, rbind(cran,local), , TRUE))
+    )
+  )
+  rec = rownames(installed.packages(, 'high'))
+  stage2 = stage2[!(stage2 %in% rec)]
   print(stage2)
 
-  download.packages(stage2,'$DISTREP/src/contrib',,c('http://rforge.net','http://r.research.att.com','file://$RCREPO'),type='source')
+  download.packages(stage2, '$DISTREP/src/contrib', , c('http://rforge.net', 'http://r.research.att.com', 'file://$RCREPO'), type = 'source')
   tools:::write_PACKAGES('$DISTREP/src/contrib')
 RCMD
 
@@ -122,9 +138,9 @@ else
     ## Installation from a distribution
     "$RBIN" --slave --vanilla <<RCMD
   cat(sprintf("\n Using %s, installing packages...\n", R.version.string))
-  url="file://'"$DISTREP/"'"
-  a=rownames(available.packages(paste0(url,"/src/contrib")))
-  install.packages(a,,url,type="source")
+  url = "file://'"$DISTREP/"'"
+  a = rownames(available.packages(paste0(url, "/src/contrib")))
+  install.packages(a, , url, type = "source")
 RCMD
 fi
 

--- a/scripts/bootstrapR.sh
+++ b/scripts/bootstrapR.sh
@@ -1,25 +1,27 @@
 #!/bin/sh
 
 if [ x"$1" = 'x-h' ]; then
-    echo ''
-    echo " Usage: $0 [--mk-dist]"
-    echo ''
-    echo ' This script must be run from the RCloud root directory and it'
-    echo ' installs R packages needed by RCloud in the R installation'
-    echo ''
-    echo ' Optional environment variables:'
-    echo ' RBIN        - location of the R executable [R]'
-    echo ' RCREPO      - repository of RCloud packages [<RCloud>/packages]'
-    echo ' DISTREP     - distribution repository [<RCloud>/dist-repos]'
-    echo ''
-    echo ' If DISTREP exists, it will be used to bootstrap R without using'
-    echo " remote repositories. If it doesn't exist, packages from RCREPO"
-    echo ' are used along with dependencies from remote repositories.'
-    echo " If RCREPO doesn't exist, it is created from the source tree."
-    echo ''
-    echo ' DISTREP can be created using --mk-dist in which case it'
-    echo ' is built from sources and remote repositories'
-    echo ''
+    cat <<EOF
+
+ Usage: $0 [--mk-dist]
+
+ This script must be run from the RCloud root directory and it
+ installs R packages needed by RCloud in the R installation
+
+ Optional environment variables:
+ RBIN        - location of the R executable [R]
+ RCREPO      - repository of RCloud packages [<RCloud>/packages]
+ DISTREP     - distribution repository [<RCloud>/dist-repos]
+
+ If DISTREP exists, it will be used to bootstrap R without using
+ remote repositories. If it doesn't exist, packages from RCREPO
+ are used along with dependencies from remote repositories.
+ If RCREPO doesn't exist, it is created from the source tree.
+
+ DISTREP can be created using --mk-dist in which case it
+ is built from sources and remote repositories
+
+EOF
     exit 0
 fi
 
@@ -36,9 +38,7 @@ fi
 
 ok=`echo 'if(R.version$major>=3)cat("OK\n")' | "$RBIN" --slave --vanilla`
 if [ "x$ok" != "xOK" ]; then
-    echo '' 1>&2
-    echo ' ERROR: R is not available in the correct version.' 1>&2
-    echo '' 1>&2
+    echo -e '\n ERROR: R is not available in the correct version.\n' 1>&2
     exit 1
 fi
 
@@ -48,6 +48,7 @@ mkdist=''
 if [ x"$1" = "x--mk-dist" ]; then
     mkdist=yes
 fi
+
 if [ -n "$mkdist" -o x"$1" = "x--clean" ]; then
     echo " --- Cleaning existing repositories"
     rm -rf "$DISTREP/src/contrib" "$RCREPO/src/contrib"
@@ -57,13 +58,21 @@ if [ ! -e "$DISTREP/src/contrib/PACKAGES" -o -n "$mkdist" ]; then
     ## we need RCREPO populated in any case
     if [ ! -e "$RCREPO/src/contrib/PACKAGES" -o -n "$mkdist" ]; then
         echo " --- Creating RCloud repository $RCREPO"
-        echo '' 1>&2
+
         if ! mkdir -p "$RCREPO/src/contrib"; then
-            echo "ERROR: cannot create src/contrib in $RCREPO, please set RCREPO if other location is desired" 1>&2
+            echo -e "\nERROR: cannot create src/contrib in $RCREPO, please set RCREPO if other location is desired" 1>&2
             exit 1
         fi
+
         echo " Builds RCloud packages"
-        ( cd "$RCREPO/src/contrib"; for src in `ls $WD/rcloud.*/DESCRIPTION $WD/rcloud.packages/*/DESCRIPTION $WD/packages/*/DESCRIPTION 2>/dev/null`; do "$RBIN" CMD build `dirname "$src"`; done )
+        (
+          cd "$RCREPO/src/contrib"
+
+          for src in `ls $WD/rcloud.*/DESCRIPTION $WD/rcloud.packages/*/DESCRIPTION $WD/packages/*/DESCRIPTION 2>/dev/null`
+          do
+            "$RBIN" CMD build `dirname "$src"`
+          done
+        )
         echo "tools:::write_PACKAGES('$RCREPO/src/contrib')" | "$RBIN" --vanilla --slave --no-save || exit 1
     fi
 
@@ -90,23 +99,27 @@ fi
 
 ok=`echo 'library(rcloud.support);library(rcloud.client);library(Cairo);library(rjson);cat("OK\n")' | "$RBIN" --slave --vanilla`
 if [ "x$ok" != "xOK" ]; then
-    echo '' 1>&2
-    echo ' ERROR: one or more packages could not be installed.' 1>&2
-    echo ' Please check that you have all necessary dependencies installed' 1>&2
-    echo '' 1>&2
+    cat <<EOF >&2
+
+ ERROR: one or more packages could not be installed.
+ Please check that you have all necessary dependencies installed
+
+EOF
     exit 1
 fi
 
-echo ''
-echo '============================================================================'
-echo ''
-echo ' IMPORTANT: please edit conf/rcloud.conf to setup your GitHub application'
-echo ' (see instructions on https://github.com/att/rcloud for the procedure)'
-echo ''
-echo ' After doing so, you can then use conf/start to start up the RCloud server'
-echo ''
-echo ' NOTE: If you use force or upgrade in check.installation() it will upgrade'
-echo '       to the latest development version of RCloud which may or may not be'
-echo '       what you want. Re-run this script if you get into trouble and want'
-echo '       back to the released version.'
-echo ''
+cat <<EOF
+
+ ============================================================================
+
+  IMPORTANT: please edit conf/rcloud.conf to setup your GitHub application
+  (see instructions on https://github.com/att/rcloud for the procedure)
+
+  After doing so, you can then use conf/start to start up the RCloud server
+
+  NOTE: If you use force or upgrade in check.installation() it will upgrade
+        to the latest development version of RCloud which may or may not be
+        what you want. Re-run this script if you get into trouble and want
+        back to the released version.
+
+EOF

--- a/scripts/bootstrapR.sh
+++ b/scripts/bootstrapR.sh
@@ -25,24 +25,17 @@ EOF
     exit 0
 fi
 
-WD=`pwd`
-
-if [ ! -e "$WD/rcloud.support/DESCRIPTION" ]; then
-    echo ' ERROR: you must run this script from the RCloud root directory!' 1>&2
-    exit 1
-fi
-
-: ${RCREPO="$WD/packages"}
-: ${DISTREP="$WD/dist-repos"}
-: ${RBIN=R}
+WD="$( cd "$( dirname $0 )/.." && pwd )"
+RCREPO=${RCREPO:-"$WD/packages"}
+DISTREP=${DISTREP:-"$WD/dist-repos"}
+RBIN=${RBIN:-"R"}
+export RCS_SILENCE_LOADCHECK=TRUE
 
 ok=`echo 'if(R.version$major>=3)cat("OK\n")' | "$RBIN" --slave --vanilla`
 if [ "x$ok" != "xOK" ]; then
     echo -e '\n ERROR: R is not available in the correct version.\n' 1>&2
     exit 1
 fi
-
-export RCS_SILENCE_LOADCHECK=TRUE
 
 mkdist=''
 if [ x"$1" = "x--mk-dist" ]; then


### PR DESCRIPTION
We wanted to update the bootstrapR.sh file to be more readable, by using heredoc syntax instead of echos and single-line R functions.

A significant change, however, was the reordering of the repos that are looked at as sources to install packages. Local packages, represented by `file://` were last in the list to look for, meaning that bootstrapR.sh preferred installing packages from online, even if one was present locally. 

We also made the script runnable from any location.
