### PR TITLE
Fixed issue #1118 - "search results overlap results header"

### DIFF
--- a/htdocs/css/edit.css
+++ b/htdocs/css/edit.css
@@ -457,6 +457,7 @@ li.jqtree-selected .notebook-commands {
 #search-summary {
     display: none;
     height: 8px;
+    margin-bottom: 8px;
 }
 
 #search-results-row {


### PR DESCRIPTION
Added 8px margin-bottom. This was not added earlier thinking to utilize maximum real estate.
But looks ugly so fixed it.
It looks like below now after adding margin.
![margin](https://cloud.githubusercontent.com/assets/391355/5284203/c26716ba-7ae0-11e4-897e-3acd0671e085.png)
