### PR TITLE
This Fixes #1135( Command prompt is shown on click of subscribe to comments also)

### DIFF
--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -77,10 +77,7 @@ RCloud.UI.settings_frame = (function() {
                     id:"subscribe-to-comments",
                     sort: 100,
                     default_value: false,
-                    label: "Subscribe To Comments",
-                    set: function(val) {
-                        RCloud.UI.command_prompt.show_prompt(val);
-                    }
+                    label: "Subscribe To Comments"
                 })
             });
         },


### PR DESCRIPTION
Detached the command prompt setting from subscribe to comments option.
@gordonwoodhull Please review and merge the Fix
