### PR TITLE
 Fixed #1039 : what if the tag doesn't exist?

### DIFF
--- a/htdocs/edit.js
+++ b/htdocs/edit.js
@@ -1,42 +1,35 @@
 function main() {
     Promise.longStackTraces();
 
-    function getURLParameter(name) {
-        return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
-    }
-
     RCloud.UI.init();
     RCloud.session.init().then(function() {
         var opts = {};
         return RCloud.UI.load_options().then(function() {
-            if (location.search.length > 0) {
-                opts.notebook = getURLParameter("notebook");
-                opts.version = getURLParameter("version");
-                if (opts.notebook === null && getURLParameter("new_notebook"))
+            if(location.search.length > 0) {
+                var notebook = ui_utils.getURLParameter("notebook"),
+                    new_notebook = ui_utils.getURLParameter("new_notebook"),
+                    version = ui_utils.getURLParameter("version"),
+                    quiet = ui_utils.getURLParameter("quiet"),
+                    tag = ui_utils.getURLParameter("tag"),
+                    user = ui_utils.getURLParameter("user"),
+                    path = ui_utils.getURLParameter("path");
+
+                opts.notebook = notebook;
+                opts.version = version;
+                if(opts.notebook === null && new_notebook)
                     opts = {new_notebook: true};
                 var promise = Promise.resolve(undefined);
-                if (opts.notebook === null && getURLParameter("user")) {
-                    promise = rcloud.get_notebook_by_name(getURLParameter("path"), getURLParameter("user"))
+                if(opts.notebook === null && user) {
+                    promise = rcloud.get_notebook_by_name(path, user)
                         .then(function(result) {
                             opts.notebook = result[0];
                         });
                 }
-                var tag = getURLParameter("tag");
                 if(!opts.version && tag) {
-                    promise = promise.then(function() {
-                        return rcloud.get_version_by_tag(opts.notebook, tag)
-                            .then(function(version) {
-                                opts.version = version;
-                                if(version === null) {
-                                    var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
-                                    var make_edit_url = ui_utils.url_maker('edit.html');
-                                    RCloud.UI.fatal_dialog(message, "Continue", make_edit_url());
-                                    return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
-                                }
-                            });
-                    });
-                };
-                return promise;
+                    return ui_utils.check_tag_exists('edit.html', promise);
+                } else {
+                    return promise;
+                }
             }
             return undefined;
         }).then(shell.init.bind(shell))

--- a/htdocs/edit.js
+++ b/htdocs/edit.js
@@ -27,7 +27,7 @@ function main() {
                 }
                 if(!opts.version && tag) {
                     promise = promise.then(function() {
-                        return rcloud.get_version_by_tag(notebook, tag)
+                        return rcloud.get_version_by_tag(opts.notebook, tag)
                             .then(function(v) {
                                 if(v === null) {
                                     ui_utils.check_tag_exists('edit.html', opts.notebook);

--- a/htdocs/edit.js
+++ b/htdocs/edit.js
@@ -30,7 +30,7 @@ function main() {
                         return rcloud.get_version_by_tag(notebook, tag)
                             .then(function(v) {
                                 if(v === null) {
-                                    ui_utils.check_tag_exists('edit.html');
+                                    ui_utils.check_tag_exists('edit.html', opts.notebook);
                                     return Promise.reject(new Error("Attempt to load a notebook with tag which does not exist."));
                                 } else {
                                     opts.version = v;

--- a/htdocs/edit.js
+++ b/htdocs/edit.js
@@ -27,6 +27,12 @@ function main() {
                         return rcloud.get_version_by_tag(opts.notebook, tag)
                             .then(function(version) {
                                 opts.version = version;
+                                if(version === null) {
+                                    var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
+                                    var make_edit_url = ui_utils.url_maker('edit.html');
+                                    RCloud.UI.fatal_dialog(message, "Continue", make_edit_url());
+                                    return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
+                                }
                             });
                     });
                 };

--- a/htdocs/edit.js
+++ b/htdocs/edit.js
@@ -26,10 +26,19 @@ function main() {
                         });
                 }
                 if(!opts.version && tag) {
-                    return ui_utils.check_tag_exists('edit.html', promise);
-                } else {
-                    return promise;
-                }
+                    promise = promise.then(function() {
+                        return rcloud.get_version_by_tag(notebook, tag)
+                            .then(function(v) {
+                                if(v === null) {
+                                    ui_utils.check_tag_exists('edit.html');
+                                    return Promise.reject(new Error("Attempt to load a notebook with tag which does not exist."));
+                                } else {
+                                    opts.version = v;
+                                }
+                            });
+                    });
+                };
+                return promise;
             }
             return undefined;
         }).then(shell.init.bind(shell))

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -16,6 +16,25 @@ ui_utils.url_maker = function(page) {
         return url;
     };
 };
+ui_utils.getURLParameter =  function(name){
+    return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
+}
+
+ui_utils.check_tag_exists = function(page,promise) {
+    console.log("page---"+page);
+    var tag = ui_utils.getURLParameter("tag"),
+        notebook = ui_utils.getURLParameter("notebook");
+    return rcloud.get_version_by_tag(notebook, tag)
+        .then(function(v) {
+            if(v === null) {
+                var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
+                var make_edit_url = ui_utils.url_maker(page);
+                console.log("make_edit_url----"+make_edit_url);
+                RCloud.UI.fatal_dialog(message, "Continue", make_edit_url({notebook: notebook}));
+                return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
+            }
+        });
+};
 
 ui_utils.disconnection_error = function(msg, label) {
     var result = $("<div class='alert alert-danger'></div>");

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -21,9 +21,8 @@ ui_utils.getURLParameter =  function(name){
     return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
 }
 
-ui_utils.check_tag_exists = function(page) {
-    var tag = ui_utils.getURLParameter("tag"),
-        notebook = ui_utils.getURLParameter("notebook");
+ui_utils.check_tag_exists = function(page, notebook) {
+    var tag = ui_utils.getURLParameter("tag");
     var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
     var make_edit_url = ui_utils.url_maker(page);
     return RCloud.UI.fatal_dialog(message, "Continue", make_edit_url({notebook: notebook}));

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -16,24 +16,17 @@ ui_utils.url_maker = function(page) {
         return url;
     };
 };
+
 ui_utils.getURLParameter =  function(name){
     return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
 }
 
-ui_utils.check_tag_exists = function(page,promise) {
-    console.log("page---"+page);
+ui_utils.check_tag_exists = function(page) {
     var tag = ui_utils.getURLParameter("tag"),
         notebook = ui_utils.getURLParameter("notebook");
-    return rcloud.get_version_by_tag(notebook, tag)
-        .then(function(v) {
-            if(v === null) {
-                var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
-                var make_edit_url = ui_utils.url_maker(page);
-                console.log("make_edit_url----"+make_edit_url);
-                RCloud.UI.fatal_dialog(message, "Continue", make_edit_url({notebook: notebook}));
-                return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
-            }
-        });
+    var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
+    var make_edit_url = ui_utils.url_maker(page);
+    return RCloud.UI.fatal_dialog(message, "Continue", make_edit_url({notebook: notebook}));
 };
 
 ui_utils.disconnection_error = function(msg, label) {

--- a/htdocs/mini.js
+++ b/htdocs/mini.js
@@ -30,8 +30,19 @@ function main() {
 
             // resolve(rcloud.init_client_side_data()); // what was this for?!?
 
-            if(!version && tag)
-                return ui_utils.check_tag_exists('mini.html', promise);
+            if(!version && tag) {
+                promise = promise.then(function() {
+                    return rcloud.get_version_by_tag(notebook, tag)
+                        .then(function(v) {
+                            if(v === null) {
+                                ui_utils.check_tag_exists('mini.html');
+                                return Promise.reject(new Error("Attempt to load a notebook with tag which does not exist."));
+                            } else {
+                                version = v;
+                            }
+                        });
+                });
+            };
 
             promise = promise.then(function() {
                 return rcloud.call_notebook(notebook, version).then(function(x) {

--- a/htdocs/mini.js
+++ b/htdocs/mini.js
@@ -35,7 +35,7 @@ function main() {
                     return rcloud.get_version_by_tag(notebook, tag)
                         .then(function(v) {
                             if(v === null) {
-                                ui_utils.check_tag_exists('mini.html');
+                                ui_utils.check_tag_exists('mini.html', notebook);
                                 return Promise.reject(new Error("Attempt to load a notebook with tag which does not exist."));
                             } else {
                                 version = v;

--- a/htdocs/mini.js
+++ b/htdocs/mini.js
@@ -36,6 +36,12 @@ function main() {
                 promise = promise.then(function() {
                     return rcloud.get_version_by_tag(notebook, tag)
                         .then(function(v) {
+                            if(v === null) {
+                                var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
+                                var make_edit_url = ui_utils.url_maker('edit.html');
+                                RCloud.UI.fatal_dialog(message, "Continue", make_edit_url());
+                                return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
+                            }
                             version = v;
                         });
                 });

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -1,16 +1,15 @@
 function main() {
     Promise.longStackTraces();
 
-    function getURLParameter(name) {
-        return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||null;
-    }
-
     RCloud.UI.init();
     RCloud.session.init(true).then(function() {
         shell.init();
-        var notebook = getURLParameter("notebook"),
-            version = getURLParameter("version"),
-            quiet = getURLParameter("quiet");
+        var notebook = ui_utils.getURLParameter("notebook"),
+            version = ui_utils.getURLParameter("version"),
+            quiet = ui_utils.getURLParameter("quiet"),
+            tag = ui_utils.getURLParameter("tag"),
+            user = ui_utils.getURLParameter("user"),
+            path = ui_utils.getURLParameter("path");
 
         var promise = Promise.resolve(true);
         if (Number(quiet)) {
@@ -20,28 +19,17 @@ function main() {
                 rcloud.api.disable_echo();
             });
         }
-        if (notebook === null && getURLParameter("user")) {
+        if(notebook === null && user) {
             promise = promise.then(function() {
-                return rcloud.get_notebook_by_name(getURLParameter("path"), getURLParameter("user"));
+                return rcloud.get_notebook_by_name(path, user);
             }).then(function(result) {
                 notebook = result[0];
             });
         }
-        var tag = getURLParameter("tag");
-        if(!version && tag) {
-            promise = promise.then(function() {
-                return rcloud.get_version_by_tag(notebook, tag)
-                    .then(function(v) {
-                        if(v === null) {
-                            var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
-                            var make_edit_url = ui_utils.url_maker('edit.html');
-                            RCloud.UI.fatal_dialog(message, "Continue", make_edit_url());
-                            return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
-                        }
-                        version = v;
-                    });
-            });
-        };
+
+        if(!version && tag)
+            return ui_utils.check_tag_exists('view.html', promise);
+
         promise = promise.then(function() {
             return shell.load_notebook(notebook, version).then(
                 function(result) {

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -31,7 +31,7 @@ function main() {
                 return rcloud.get_version_by_tag(notebook, tag)
                     .then(function(v) {
                         if(v === null) {
-                            ui_utils.check_tag_exists('view.html');
+                            ui_utils.check_tag_exists('view.html', notebook);
                             return Promise.reject(new Error("Attempt to load a notebook with tag which does not exist."));
                         } else {
                             version = v;

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -32,6 +32,12 @@ function main() {
             promise = promise.then(function() {
                 return rcloud.get_version_by_tag(notebook, tag)
                     .then(function(v) {
+                        if(v === null) {
+                            var message = "Tag [" + tag + "] in url is incorrect or doesn't exist. Please click Continue to load the most recent version of the notebook";
+                            var make_edit_url = ui_utils.url_maker('edit.html');
+                            RCloud.UI.fatal_dialog(message, "Continue", make_edit_url());
+                            return Promise.reject(new Error("attempted to load a notebook with tag which does not exist"));
+                        }
                         version = v;
                     });
             });

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -26,10 +26,19 @@ function main() {
                 notebook = result[0];
             });
         }
-
-        if(!version && tag)
-            return ui_utils.check_tag_exists('view.html', promise);
-
+        if(!version && tag) {
+            promise = promise.then(function() {
+                return rcloud.get_version_by_tag(notebook, tag)
+                    .then(function(v) {
+                        if(v === null) {
+                            ui_utils.check_tag_exists('view.html');
+                            return Promise.reject(new Error("Attempt to load a notebook with tag which does not exist."));
+                        } else {
+                            version = v;
+                        }
+                    });
+            });
+        };
         promise = promise.then(function() {
             return shell.load_notebook(notebook, version).then(
                 function(result) {


### PR DESCRIPTION
As described in the issue added below fix :
1>added fatal_dialog (Aw Shucks) message if the user tries to load with tag which doesn't exist.
2>provided two options in dialog ignore and continue. If Ignore is pressed GUI is left with a unusable state but user can copy the error message from session info pane.
3>rejected the promise with custom error so that this can be captured in session info pane as mentioned in point 2. Reason is currently there is no error thrown we directly reload the last notebook.
4>Added this same logic for view and mini.
Screenshots attcahed after testing:
![tag1](https://cloud.githubusercontent.com/assets/391355/5408483/6eb680a8-81a9-11e4-8c49-eef15b83db1b.png)
If Ignore is clicked:
![tag2](https://cloud.githubusercontent.com/assets/391355/5408486/6ebb358a-81a9-11e4-8fe9-698d7a18a36e.png)
If continue is clicked:
![tag3](https://cloud.githubusercontent.com/assets/391355/5408484/6eb79c18-81a9-11e4-84d8-6ff066de3a87.png)
View.html
![tag4](https://cloud.githubusercontent.com/assets/391355/5408482/6eb4328a-81a9-11e4-9a45-24affad730ab.png)
mini.html
![tag5](https://cloud.githubusercontent.com/assets/391355/5408481/6eb40760-81a9-11e4-8a29-0d1d772ed413.png)
shiny.html
![tag6](https://cloud.githubusercontent.com/assets/391355/5408485/6eb96a8e-81a9-11e4-80ed-1106120885fb.png)
With shiny somehow the dialogue doesn't come. I tried to figure out but couldn't looks like its handled ina  different way. 
@gordonwoodhull :Please let me know if this is the fix you were looking for.
