### PR TITLE
This Fixes #1134, #931 : Changing checkbox style

### DIFF
--- a/htdocs/css/edit.css
+++ b/htdocs/css/edit.css
@@ -1121,4 +1121,29 @@ pre > .vt100 {
     border-color: #ccc;
     border-radius: 3px;
 }
-
+.checkbox {
+    padding-left: 2px;
+    margin-top: 0px;
+    margin-bottom: 5px;
+}
+/* switching off default bootstrap input type checkbox*/
+input[type=checkbox] {
+    display: none;
+}
+input[type=checkbox] + span:before {
+    font-family: "FontAwesome";
+    width: 1.2em;
+    display:inline-block;
+}
+input[type=checkbox] + span:before {
+    content: "\f096"; 
+}
+input[type=checkbox]:checked + span:before {
+    content: "\f046"; 
+}
+input[type=checkbox].inverse + span:before {
+    content: "\f0c8"; 
+}
+input[type=checkbox].inverse:checked + span:before {
+    content: "\f14a"; 
+}

--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -179,8 +179,12 @@
           <button id="upload-submit" class="btn btn-default-ext" type="submit" style="clear: both;float: right;width: 33px;">
             <i class="icon-upload-alt"></i>
           </button>
-          <br/>
-          <input type="checkbox" id="upload-to-notebook"> Upload to notebook</input>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" id="upload-to-notebook"/>
+              <span>Upload to notebook</span>
+	    </label>
+          </div>
           <div class="progress" style="display:none">
             <div id="progress-bar" class="progress-bar" id="file-progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
           </div>

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -44,13 +44,15 @@ RCloud.UI.settings_frame = (function() {
                 create_control: function(on_change) {
                     var check = $.el.input({type: 'checkbox'});
                     $(check).prop('id', opts.id);
-                    var label = $($.el.label(check, opts.label));
+                    var span = $.el.span(opts.label);
+                    var label = $.el.label(check, span);
+                    var checkboxdiv = $($.el.div({class: 'checkbox'}, label));
                     $(check).change(function() {
                         var val = $(this).prop('checked');
                         on_change(val, this.id);
                         opts.set(val);
                     });
-                    return label;
+                    return checkboxdiv;
                 },
                 set: function(val, control) {
                     val = !!val;


### PR DESCRIPTION
fixing settings checkbox pile-up issue as well as custom checkbox style

1 > Switched off default checkbox style in edit.css
2> Created custom checkbox style in edit.css
3> Fixed checkbox pile-up isue in settings panel
4> Applied same style for file upload checkbox
Screenshot attached after testing :
![seetings-check-box](https://cloud.githubusercontent.com/assets/6388509/5416472/e6fd148a-8255-11e4-97e9-2f8436ba2bf5.PNG)

Going forward this style will be applied to any new  checkbox added.

@gordonwoodhull 
Please review and let me know if this is fine.
