### PR TITLE
This Fixes #611 : removing extra line break while merging cells

### DIFF
--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -292,7 +292,7 @@ Notebook.create_controller = function(model)
             function crunch_quotes(left, right) {
                 var end = /```\n$/, begin = /^```{r}/;
                 if(end.test(left) && begin.test(right))
-                    return left.replace(end, '') + right.replace(begin, '');
+                    return left.replace(end, '') + right.replace(begin, '').replace(/^(\r\n|\n|\r)/, "");
                 else return left + right;
             }
 


### PR DESCRIPTION
1> Replaced extra line break with blank in notebook_controller.js
2> New line character has been taken care for windows, unix and mac
3> Cell merge is working for all 4 cases i.e. R+R, R+Markdown, Markdown+R and Markdown+Markdown
Screenshot attached after testing :
![r_r_coalesce](https://cloud.githubusercontent.com/assets/6388509/5485456/53ad391a-86c1-11e4-8b08-eaeb74941063.PNG)
![r-markdown_coalesce](https://cloud.githubusercontent.com/assets/6388509/5485457/5f5cb01a-86c1-11e4-8c10-42de0c92ed18.PNG)
![markdown_r_coalesce](https://cloud.githubusercontent.com/assets/6388509/5485461/6bbf63b6-86c1-11e4-8608-ab9eeb713525.PNG)
![markdown_markdown_coalesce](https://cloud.githubusercontent.com/assets/6388509/5485464/70e177a8-86c1-11e4-9ed5-5c658c2255f8.PNG)

@gordonwoodhull 
Please review and let me know if this is fine.
