### PR TITLE
This Fixes #1037 : Loading version by tag for mini and view html

### DIFF
--- a/htdocs/mini.js
+++ b/htdocs/mini.js
@@ -32,6 +32,7 @@ function main() {
             var notebook = getURLParameter("notebook"),
                 version = getURLParameter("version");
             var tag = getURLParameter("tag");
+            var versiontotag = false;
             if(!version && tag) {
                 promise = promise.then(function() {
                     return rcloud.get_version_by_tag(notebook, tag)
@@ -39,8 +40,22 @@ function main() {
                             version = v;
                         });
                 });
+            }
+            else if(version && !tag) {
+                promise = promise.then(function () {
+                    return rcloud.get_tag_by_version(notebook, version)
+                        .then(function (t) {
+                            tag = t;
+                            if (tag)
+                                versiontotag = true;
+                        });
+                })
             };
             promise = promise.then(function() {
+                if(versiontotag) {
+                    var opts = {notebook: notebook, version: version, tag: tag};
+                    update_mini_url(opts);
+                }
                 return rcloud.call_notebook(notebook, version).then(function(x) {
                     // FIXME: I'm not sure what's the best way to make this available
                     // in a convenient manner so that notebooks can leverage it ...
@@ -63,5 +78,11 @@ function main() {
                 return false;
         }
     });
+    var make_mini_url = ui_utils.url_maker('mini.html');
+    function update_mini_url(opts) {
+        var url = make_mini_url(opts);
+        window.history.replaceState("rcloud.notebook", null, url);
+        rcloud.api.set_url(url);
+    }
 }
 

--- a/htdocs/mini.js
+++ b/htdocs/mini.js
@@ -32,7 +32,7 @@ function main() {
             var notebook = getURLParameter("notebook"),
                 version = getURLParameter("version");
             var tag = getURLParameter("tag");
-            var versiontotag = false;
+            var version_to_tag = false;
             if(!version && tag) {
                 promise = promise.then(function() {
                     return rcloud.get_version_by_tag(notebook, tag)
@@ -42,17 +42,17 @@ function main() {
                 });
             }
             else if(version && !tag) {
-                promise = promise.then(function () {
+                promise = promise.then(function() {
                     return rcloud.get_tag_by_version(notebook, version)
                         .then(function (t) {
                             tag = t;
-                            if (tag)
-                                versiontotag = true;
+                            if(tag)
+                                version_to_tag = true;
                         });
                 })
             };
             promise = promise.then(function() {
-                if(versiontotag) {
+                if(version_to_tag) {
                     var opts = {notebook: notebook, version: version, tag: tag};
                     update_mini_url(opts);
                 }

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -28,7 +28,7 @@ function main() {
             });
         }
         var tag = getURLParameter("tag");
-        var versiontotag = false;
+        var version_to_tag = false;
         if(!version && tag) {
             promise = promise.then(function() {
                 return rcloud.get_version_by_tag(notebook, tag)
@@ -43,12 +43,12 @@ function main() {
                     .then(function(t) {
                         tag = t;
                         if(tag)
-                            versiontotag = true;
+                            version_to_tag = true;
                     });
             });
         };
         promise = promise.then(function() {
-            if(versiontotag) {
+            if(version_to_tag) {
                 var opts = {notebook: notebook, version: version, tag: tag};
                 update_view_url(opts);
             }

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -28,6 +28,7 @@ function main() {
             });
         }
         var tag = getURLParameter("tag");
+        var versiontotag = false;
         if(!version && tag) {
             promise = promise.then(function() {
                 return rcloud.get_version_by_tag(notebook, tag)
@@ -35,8 +36,22 @@ function main() {
                         version = v;
                     });
             });
+        }
+        else if(version && !tag) {
+            promise = promise.then(function() {
+                return rcloud.get_tag_by_version(notebook, version)
+                    .then(function(t) {
+                        tag = t;
+                        if(tag)
+                            versiontotag = true;
+                    });
+            });
         };
         promise = promise.then(function() {
+            if(versiontotag) {
+                var opts = {notebook: notebook, version: version, tag: tag};
+                update_view_url(opts);
+            }
             return shell.load_notebook(notebook, version).then(
                 function(result) {
                     document.title = result.description + " - RCloud";
@@ -60,4 +75,10 @@ function main() {
         console.log(err.stack);
         RCloud.UI.session_pane.post_error(ui_utils.disconnection_error("Could not load notebook. You may need to login to see it.", "Login"));
     });
+    var make_view_url = ui_utils.url_maker('view.html');
+    function update_view_url(opts) {
+        var url = make_view_url(opts);
+        window.history.replaceState("rcloud.notebook", null, url);
+        rcloud.api.set_url(url);
+    }
 }


### PR DESCRIPTION
Fixing view/mini.html show &tag= instead of &version= when there's a tag

1> Created update_url function which uses html5 history api in view.js to update url
2> Created update_url function which uses html5 history api in mini.js to update url
3> update_url gets called only if tag exists for a version loaded in url
Screenshot attached after testing view.html and mini.html respectively:
![view](https://cloud.githubusercontent.com/assets/6388509/5488669/2123c33a-86e7-11e4-8f27-550a0dded4e0.gif)
![mini](https://cloud.githubusercontent.com/assets/6388509/5488671/26d1e1a4-86e7-11e4-8efa-fbf537624a1d.gif)
