### PR TITLE
This Fixes #548 : collapsing error traces

### DIFF
--- a/htdocs/css/edit.css
+++ b/htdocs/css/edit.css
@@ -732,6 +732,16 @@ li.jqtree-selected .notebook-commands {
 
 /******************************************************************************/
 
+#session-info {
+    max-height : 57px;
+    overflow-y : hidden;
+}
+
+#show-details {
+    cursor: pointer;
+    display : none;
+}
+
 #session-info-panel {
     overflow-y: auto;
     overflow-x: auto;

--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -219,6 +219,7 @@
 <script type="text/html" id="session-info-snippet">
   <div class="panel-body tight" id="session-info-panel">
     <div id="session-info" class="widget-vsize"></div>
+    <a class="details-link" id="show-details">Show Details</a>
   </div>
 </script>
 

--- a/htdocs/js/ui/session_pane.js
+++ b/htdocs/js/ui/session_pane.js
@@ -23,7 +23,15 @@ RCloud.UI.session_pane = {
                 that.clear();
             }
         });
-
+        // Link for error collapse
+        $('#show-details').click(function() {
+            $("#session-info").css('max-height', function(_, max_height) {
+                return max_height === '57px' ? 'none' : '57px';
+            })
+            $(this).html(function(_, html) {
+                return html === 'Show Details' ? 'Hide Details' : 'Show Details';
+            })
+        });
         //////////////////////////////////////////////////////////////////////
         // bluebird unhandled promise handler
         Promise.onPossiblyUnhandledRejection(function(e, promise) {
@@ -41,8 +49,10 @@ RCloud.UI.session_pane = {
         return this.error_dest_;
     },
     clear: function() {
-        if(this.allow_clear)
+        if(this.allow_clear) {
             $("#session-info").empty();
+            $('#show-details').css('display', 'none');
+        }
     },
     append_text: function(msg) {
         // FIXME: dropped here from session.js, could be integrated better
@@ -76,6 +86,7 @@ RCloud.UI.session_pane = {
             ui_utils.on_next_tick(function() {
                 ui_utils.scroll_to_after($("#session-info"));
             });
+            $('#show-details').css('display', 'block');
         }
         if(!logged)
             console.log("pre-init post_error: " + msg.text());

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -37,7 +37,9 @@ ui_utils.string_error = function(msg) {
     var button = $("<button type='button' class='close' data-dismiss='alert' aria-hidden='true'>&times;</button>");
     var result = $("<div class='alert alert-danger alert-dismissable'></div>");
     // var text = $("<span></span>");
-
+    button.click(function() {
+        $('#show-details').css('display', 'none');
+    });
     result.append(button);
     var text = _.map(msg.split("\n"), function(str) {
         // poor-man replacing 4 spaces with indent


### PR DESCRIPTION
1> Created anchor tag to show/hide details in edit.html
2> Defined click function to show/hide details, error load in session_pane.js
3> Set display to none in ui_utils.js on click of show/hide details
4> Added style for show/hide details in edit.css
5> First three lines of the error are shown followed by the ‘Show Details’ link.
6> When ‘Show Details’ is clicked the error collapses to show the whole message followed by the ‘Hide Details’ message.
Screenshot attached after testing :
![show_details](https://cloud.githubusercontent.com/assets/6388509/5548707/7594e168-8b9e-11e4-8c84-876c6b1c3199.PNG)
![hide_details](https://cloud.githubusercontent.com/assets/6388509/5548710/7acdb722-8b9e-11e4-9a2d-866d1fe6bb43.PNG)

@gordonwoodhull 
Please review and let me know if this is fine.
