### PR TITLE
This Fixes #1126 : showing cell numbers of parts

### DIFF
--- a/htdocs/css/edit.css
+++ b/htdocs/css/edit.css
@@ -211,6 +211,7 @@ rect.frame {
     width: 100%;
     height: 25px;
     background-color: #e5e5e5;
+    z-index: 4;
 }
 
 .cell-status.big {
@@ -239,6 +240,12 @@ rect.frame {
     right: -0.1em;
     top: -0.5em;
     z-index: 5;
+}
+
+.cell-sequence {
+    display : inline-block;
+    margin-left: 2px;
+    margin-top: 4px;
 }
 
 .fontawesome-button {

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -12,6 +12,8 @@ function ensure_image_has_hash(img)
 function create_markdown_cell_html_view(language) { return function(cell_model) {
     var EXTRA_HEIGHT = 27;
     var notebook_cell_div  = $("<div class='notebook-cell'></div>");
+    var cell_sequence = $("<div class='cell-sequence'></div>");
+    cell_sequence.html('#' + cell_model.id());
     update_div_id();
     notebook_cell_div.data('rcloud.model', cell_model);
 
@@ -32,6 +34,7 @@ function create_markdown_cell_html_view(language) { return function(cell_model) 
     }
     function update_div_id() {
         notebook_cell_div.attr('id', Notebook.part_name(cell_model.id(), cell_model.language()));
+        cell_sequence.html('#' + cell_model.id());
     }
     function set_widget_height() {
         notebook_cell_div.css({'height': (ui_utils.ace_editor_height(widget) + EXTRA_HEIGHT) + "px"});
@@ -95,6 +98,7 @@ function create_markdown_cell_html_view(language) { return function(cell_model) 
         execute_cell();
     });
     var cell_status = $("<div class='cell-status'></div>");
+    cell_status.append(cell_sequence);
     var button_float = $("<div class='cell-controls'></div>");
     cell_status.append(button_float);
     cell_status.append($("<div style='clear:both;'></div>"));


### PR DESCRIPTION
1> Created a div element and appended cell id to it in cell_view.js
2> Added style required for this div element and set z-index to 4, so that it can appear above the inner div , in edit.css
3> Adding a new cell from the prompt cell, below the existing cell creates  a sequentially numbered cell below it
4> Adding a new cell in between two cells renames the cells below the newly added cell
5> Moving the cell 1 over the cell 2, renames the cell 1 as 3 and similar behavior is observed further

screenshots attached after testing : 
![add_new_cell_in _between](https://cloud.githubusercontent.com/assets/6388509/5556211/09066960-8cfa-11e4-964b-1ca8d0f5044f.PNG)

![moving_1st_cell_over_2nd](https://cloud.githubusercontent.com/assets/6388509/5556213/090b5cae-8cfa-11e4-9175-e779db74ef18.PNG)

![numbering](https://cloud.githubusercontent.com/assets/6388509/5556212/0906f880-8cfa-11e4-855d-ee7736653a09.PNG)

@gordonwoodhull 
Please review and let me know if this is fine.