### PR TITLE
This Fixes #972 : ellipses for notebook title and collapse navbar

### DIFF
--- a/htdocs/css/edit.css
+++ b/htdocs/css/edit.css
@@ -964,11 +964,14 @@ a.accordion-toggle.right > i {
     position: absolute;
     bottom: 4px;
     left: 6ex;
-    width: 700;
     pointer-events: none;
     cursor: text;
-    overflow-y: hidden;
+    overflow: hidden;
     height: 1.5em;
+    max-width: 95%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #forked-from-desc a {
@@ -1154,3 +1157,13 @@ input[type=checkbox].inverse + span:before {
 input[type=checkbox].inverse:checked + span:before {
     content: "\f14a"; 
 }
+
+/* handling word-wrap of text in different browsers*/
+.notebook-title-row {
+    white-space: pre-wrap; /* css-3 */
+    white-space: -moz-pre-wrap; /* Mozilla */
+    white-space: -pre-wrap; /* Opera 4-6 */
+    white-space: -o-pre-wrap; /* Opera 7 */
+    word-wrap: break-word; /* Internet Explorer 5.5 */
+}
+

--- a/htdocs/css/view.css
+++ b/htdocs/css/view.css
@@ -178,11 +178,15 @@ rect.frame {
     position: absolute;
     bottom: 4px;
     left: 6ex;
-    width: 700;
     pointer-events: none;
     cursor: text;
-    overflow-y: hidden;
+    overflow: hidden;
     height: 1.5em;
+    max-width: 95%;
+    min-width: 95%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #forked-from-desc a {

--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -35,15 +35,15 @@
     <script type="text/javascript" data-main="/lib/js/require-edit.js" src="/lib/js/require.js"></script>
   </head>
 <body style="overflow:hidden">
-<div class="navbar navbar-inverse navbar-fixed-top">
-  <div>
+<nav class="navbar navbar-inverse navbar-fixed-top">
+  <div class="container-fluid">
     <!--div class="container"-->
-      <div class="navbar-header">
-        <a class="navbar-brand" href="#">RCloud</a>
-      </div>
-      <div class="nav-collapse">
-        <ul class="nav navbar-nav">
-          <li><span><a href="#" id="share-link" title="Shareable Link" class="btn btn-link navbar-btn" style="text-decoration:none; padding-right: 0px" target="_blank"><i class="icon-share"></i></a>
+    <div class="collapse navbar-collapse" id="navbar-title">
+      <ul class="nav navbar-nav" style="width: 85%">
+        <li>
+          <a class="navbar-brand" href="#">RCloud</a>
+        </li>
+        <li><span><a href="#" id="share-link" title="Shareable Link" class="btn btn-link navbar-btn" style="text-decoration:none; padding-right: 0px" target="_blank"><i class="icon-share"></i></a>
               <span class="dropdown" style="position:relative; margin-left: -2px; padding-right: 12px">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" id="view-mode"><b class="caret"></b></a>
                 <ul class="dropdown-menu view-menu" id="view-type">
@@ -54,36 +54,36 @@
                 </ul>
               </span>
           </span></li> <!-- the span breaks the damn bootstrap li > a before .btn business-->
-          <li><button id="star-notebook" title="Add to Interests" type="button" class="btn btn-link navbar-btn" style="padding-left: 3px"><i class="icon-star-empty"></i><sub><span id="curr-star-count" /></sub></button></li>
-          <li><button id="fork-notebook" title="Fork" type="button" class="btn btn-link navbar-btn"><i class="icon-code-fork"></i></button></li>
-          <li><button id="save-notebook" title="Save" type="button" class="btn btn-link navbar-btn disabled" style="display:none;"><i class="icon-save"></i></button></li>
-          <li><button id="revert-notebook" title="Revert" type="button" class="btn btn-link navbar-btn" style="display:none;"><i class="icon-undo"></i></button></li>
-          <li><button id="run-notebook" title="Run All" type="button" class="btn btn-link navbar-btn"><i class="icon-play"></i></button></li>
-          <li><a href="#"><span id="notebook-author"></span><span id="author-title-dash" style="display:none;">&nbsp;&ndash;&nbsp;</span><span id="rename-notebook" title="Change Title" style="display:none">[<span id="notebook-title"></span>]</a></span><small id="forked-from-desc"></small></li>
-          <li><a href="#" id="readonly-notebook" style="display:none;">(read-only)</a></li>
-          <li><a href="#"><span id="loading"><img id="loading-animation" src="/img/processing.gif" style="height: 20px;width:20px;margin:0"></img></span></a></li>
-        </ul>
-        <ul class="nav navbar-nav navbar-right">
-          <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Advanced <b class="caret"></b></a>
-            <ul class="dropdown-menu" id="advanced-menu">
-              <li><a href="#" id="open-in-github">Open in GitHub</a></li>
-              <li><a href="#" id="open-from-github">Load Notebook by ID</a></li>
-              <li><a href="#" id="import-notebooks">Import External Notebooks</a></li>
-              <li><a href="#" id="export-notebook-file">Export Notebook to File</a></li>
-              <li><a href="#" id="import-notebook-file">Import Notebook from File</a></li>
-              <li><a href="#" id="export-notebook-as-r">Export Notebook as R Source File</a></li>
-              <li><a href="#" id="show-source"><i class="icon-check"></i>&nbsp;Show Source</a></li>
-              <li><a href="#" id="publish-notebook"><i class="icon-check"></i>&nbsp;Publish notebook</a></li>
-            </ul>
-          </li>
-          <li class="divider-vertical"></li>
-          <li><a href="#" id="rcloud-logout">Logout</a></li>
-        </ul>
-      </div>
+        <li><button id="star-notebook" title="Add to Interests" type="button" class="btn btn-link navbar-btn" style="padding-left: 3px"><i class="icon-star-empty"></i><sub><span id="curr-star-count" /></sub></button></li>
+        <li><button id="fork-notebook" title="Fork" type="button" class="btn btn-link navbar-btn"><i class="icon-code-fork"></i></button></li>
+        <li><button id="save-notebook" title="Save" type="button" class="btn btn-link navbar-btn disabled" style="display:none;"><i class="icon-save"></i></button></li>
+        <li><button id="revert-notebook" title="Revert" type="button" class="btn btn-link navbar-btn" style="display:none;"><i class="icon-undo"></i></button></li>
+        <li><button id="run-notebook" title="Run All" type="button" class="btn btn-link navbar-btn"><i class="icon-play"></i></button></li>
+        <li style="max-width: 68%" class="notebook-title-row"><a href="#"><span id="notebook-author"></span><span id="author-title-dash" style="display:none;">&nbsp;&ndash;&nbsp;</span><span id="rename-notebook" title="Change Title" style="display:none">[<span id="notebook-title"></span>]</span></a><small id="forked-from-desc"></small></li>
+        <li><a href="#" id="readonly-notebook" style="display:none;">(read-only)</a></li>
+        <li><a href="#"><span id="loading"><img id="loading-animation" src="/img/processing.gif" style="height: 20px;width:20px;margin:0"></img></span></a></li>
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Advanced <b class="caret"></b></a>
+          <ul class="dropdown-menu" id="advanced-menu">
+            <li><a href="#" id="open-in-github">Open in GitHub</a></li>
+            <li><a href="#" id="open-from-github">Load Notebook by ID</a></li>
+            <li><a href="#" id="import-notebooks">Import External Notebooks</a></li>
+            <li><a href="#" id="export-notebook-file">Export Notebook to File</a></li>
+            <li><a href="#" id="import-notebook-file">Import Notebook from File</a></li>
+            <li><a href="#" id="export-notebook-as-r">Export Notebook as R Source File</a></li>
+            <li><a href="#" id="show-source"><i class="icon-check"></i>&nbsp;Show Source</a></li>
+            <li><a href="#" id="publish-notebook"><i class="icon-check"></i>&nbsp;Publish notebook</a></li>
+          </ul>
+        </li>
+        <li class="divider-vertical"></li>
+        <li><a href="#" id="rcloud-logout">Logout</a></li>
+      </ul>
+    </div>
     <!--/div-->
   </div>
-</div>
+</nav>
 
 <!-- snippets for panels, see load_snippet -->
 <script type="text/html" id="notebooks-snippet">

--- a/htdocs/js/ui/notebook_title.js
+++ b/htdocs/js/ui/notebook_title.js
@@ -50,8 +50,9 @@ RCloud.UI.notebook_title = (function() {
             var active_text = text;
             var ellipt_start = false, ellipt_end = false;
             var title = $('#notebook-title');
+            var author_name = $('#notebook-author');
             title.text(text);
-            while(window.innerWidth - title.width() < 650) {
+            while((author_name.width() + title.width()) > (window.innerWidth*52/100)) {
                 var slash = text.search('/');
                 if(slash >= 0) {
                     ellipt_start = true;


### PR DESCRIPTION
Fixing long title name causes navbar layout problem. It partially fixes #1055 as component's won't collapse on each other.

Changes:
1> Edit.css
        a)Created style for notebook-title li element to handle word-wrap in different browsers
        b)Changed fork-from-desc li element style to remove scroll bar which was coming when forked from a notebook with long title
2> Changed fork-from-desc li element style to remove scroll bar which was coming when forked from a notebook with long title in view.css
3> Edit.html
     a) Set maximum width for notebook-title for word-wrap in edit.html
     b) Change div tag of navbar to nav tag to use all properties of navbar
4> Changed logic to generate ellipses dynamically with respect to window size(in %) in notebook_title.js

Behavior:
1> The navbar is displayed as shown below. The name of the notebook goes to the next line with a fixed number of characters on one line. On pressing ‘Enter’ it will return to the normal size in single line with ellipsis.
![notebook-title](https://cloud.githubusercontent.com/assets/6388509/5586349/36124ce4-90f1-11e4-8f97-a881ef397a95.png)

2> The name of the forked notebook will be shown as below. It will also have ellipsis if the name is long. The ‘forked from’ statement will also run parallel to the name of the notebook.
![fork-by](https://cloud.githubusercontent.com/assets/6388509/5586350/3c087efc-90f1-11e4-8dba-e2844c83faad.png)

3> The ‘forked from’ statement will continue as follows but will be limited to one line
![small](https://cloud.githubusercontent.com/assets/6388509/5586353/4cb3c9f0-90f1-11e4-95b0-5eded372cd17.png)

@gordonwoodhull 
Please review it and let me know if this is correct.
