### PR TITLE
Fixes #1333 Return null if not subsettable

### DIFF
--- a/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
+++ b/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
@@ -19,7 +19,7 @@ rcloud.enviewer.display.value <- function(val) {
    classOfObject <- if (is.numeric(val)) {
     typeof(val)
   } else {
-    class(val)
+    paste0(class(val),collapse=', ')
   }
     disp <- function(classOfObject,x)
       switch(classOfObject,

--- a/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
+++ b/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
@@ -28,12 +28,13 @@ rcloud.enviewer.display.value <- function(val) {
         x)
       if(length(val) >1){
         if(is.null(dim(val))){
-           dimensionOfObject <- paste0('[1:', length(val), ']' , sep='') 
+           dimensionOfObject <- paste0(' [1:', length(val), ']' , sep='') 
         } else {
-           dimensionOfObject <- paste0('[',dim(val)[1],' x ',dim(val)[2],']')
+           dimensionOfObject <- paste0(' [',dim(val)[1],' x ',dim(val)[2],']')
         }
+        sampleval <- tryCatch({head(val,5)},error=function(err){}) 
 
-      list(type=paste0(classOfObject,dimensionOfObject), value= paste(head(val,5),collapse=', ') )
+      list(type=paste0(classOfObject,dimensionOfObject), value= paste(sampleval,collapse=', '))
     }
     else list(type=classOfObject, value=disp(classOfObject, val))
 }

--- a/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
+++ b/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
@@ -29,10 +29,12 @@ rcloud.enviewer.display.value <- function(val) {
       if(length(val) >1){
         if(is.null(dim(val))){
            dimensionOfObject <- paste0(' [1:', length(val), ']' , sep='') 
+           sampleval <- tryCatch({head(val,5)},error=function(err){}) 
         } else {
            dimensionOfObject <- paste0(' [',dim(val)[1],' x ',dim(val)[2],']')
+           sampleval <- tryCatch({head(val,1)},error=function(err){}) 
         }
-        sampleval <- tryCatch({head(val,5)},error=function(err){}) 
+        
 
       list(type=paste0(classOfObject,dimensionOfObject), value= paste(sampleval,collapse=', '))
     }


### PR DESCRIPTION
``` e <- environment(rcloud.out) ```
```e	environment [1:238]```
@s-u handling all non subsettable objects with returning null from sample