### PR TITLE
fix for #1786 - get history index updated

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1072,9 +1072,11 @@ var editor = function () {
             return histories_[current_.notebook];
         },
         get_current_notebook_history_index : function() {
-            return find_index(this.get_current_notebook_histories(), function(h) {
-                return h.version === current_.version;
-            });
+            return current_.version === null ? 
+                0 :
+                find_index(this.get_current_notebook_histories(), function(h) {
+                    return h.version === current_.version;
+                });
         },
         get_history_by_index : function(index) {
             return histories_[current_.notebook][index];


### PR DESCRIPTION
`get_current_notebook_history_index` wasn't accounting for a null value for `current_.version`; I have changed the code so that it now does so, and this has fixed the 'latest version redo' bug.

this fixes #1786 