### PR TITLE
Secured SOLR with HTTP Basic Auth

### DIFF
--- a/rcloud.support/R/notebook.comments.R
+++ b/rcloud.support/R/notebook.comments.R
@@ -10,8 +10,8 @@ rcloud.get.comments <- function(id, source = NULL) {
 .solr.post.comment <- function(id, content, comment.id) {
   
   ## query ID to see if it has existing comments
-  query <- paste0("q=id:",id,"&start=0&rows=1000&wt=json&sort=starcount desc")
-  solr.res <- .solr.get(URLencode(query))
+  query <- list(q=paste0("id:",id),start=0,rows=1000)
+  solr.res <- .solr.get(query=query)
   comment.content <- fromJSON(content)
   
   ## pick set/add depending on the exsitng content
@@ -19,7 +19,7 @@ rcloud.get.comments <- function(id, source = NULL) {
 
   ## send the update request
   metadata <- paste0('{"id":"', id, '","comments":{"', method, '":"', paste(comment.id,':::',comment.content,':::',.session$username), '"}}')
- .solr.post(metadata)
+ .solr.post(data=metadata)
 }
 
 rcloud.post.comment <- function(id, content)
@@ -31,13 +31,12 @@ rcloud.post.comment <- function(id, content)
 }
 
 .solr.modify.comment <- function(id, content, cid) {
-  url <- getConf("solr.url")
-  query <- paste0("q=id:",id,"&start=0&rows=1000&fl=comments&wt=json")
-  solr.res <- .solr.get(URLencode(query))
+  query <- list(q=paste0("id:",id),start=0,rows=1000)
+  solr.res <- .solr.get(query=query)
   index <- grep(cid, solr.res$response$docs[[1]]$comments)
   solr.res$response$docs[[1]]$comments[[index]] <- paste(cid, fromJSON(content)$body, sep=' : ')
   metadata <- paste0('{"id":"',id,'","comments":{"set":[\"',paste(solr.res$response$docs[[1]]$comments, collapse="\",\""),'\"]}}')
-  .solr.post(metadata)
+  .solr.post(data=metadata)
 }
 
 rcloud.modify.comment <- function(id, cid, content)
@@ -49,13 +48,12 @@ rcloud.modify.comment <- function(id, cid, content)
 }
 
 .solr.delete.comment <- function(id, cid) {
-  url <- getConf("solr.url")
-  query <- paste0("q=id:",id,"&start=0&rows=1000&fl=comments&wt=json")
-  solr.res <- .solr.get(URLencode(query))
+  query <- list(q=paste0("id:",id),start=0,rows=1000)
+  solr.res <- .solr.get(query=query)
   index <- grep(cid, solr.res$response$docs[[1]]$comments)
   solr.res$response$docs[[1]]$comments <- solr.res$response$docs[[1]]$comments[-index]
   metadata <- paste0('{"id":"',id,'","comments":{"set":[\"',paste(solr.res$response$docs[[1]]$comments, collapse="\",\""),'\"]}}')
-  .solr.post(metadata)
+  .solr.post(data=metadata)
 }
 
 rcloud.delete.comment <- function(id,cid)

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -373,8 +373,6 @@ rcloud.update.notebook <- function(id, content, is.current = TRUE) {
   solr.get.url$query <- query
   # https://cwiki.apache.org/confluence/display/solr/Response+Writers
   solr.get.url$query$wt<-"json"
-  # DELETE ME
-  print(build_url(solr.get.url))
   solr.res <- httr::GET(build_url(solr.get.url),content_type_json(),accept_json(),authenticate(solr.auth.user,solr.auth.pwd))
   solr.res <- fromJSON(content(solr.res, "parsed"))
   return(solr.res)
@@ -423,12 +421,8 @@ rcloud.search <-function(query, all_sources, sortby, orderby, start, pagesize) {
   solr.query <- list(q=query,start=start,rows=pagesize,indent="true",hl="true",hl.preserveMulti="true",hl.fragsize=0,hl.maxAnalyzedChars=-1
     ,fl="description,id,user,updated_at,starcount",hl.fl="content,comments",sort=paste(sortby,orderby))
   query <- function(solr.url,source='',solr.auth.user=NA,solr.auth.pwd=NA) {
-      #solr.res <- httr::GET(build_url(solr.get.url),accept_json(),add_headers("auth-key"=as.character(solr.authkey)))
       solr.res <- .solr.get(solr.url=solr.url,query=solr.query,solr.auth.user=as.character(solr.auth.user),solr.auth.pwd=as.character(solr.auth.pwd))
       if (!is.null(solr.res$error)) stop(paste0(solr.res$error$code,": ",solr.res$error$msg))
-      #return(solr.res)
-      #solr.res <- fromJSON(content(solr.res, "parsed")) 
-      print ("Check 2")
       response.docs <- solr.res$response$docs
       count <- solr.res$response$numFound
       rows <- solr.res$params$rows

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -361,7 +361,7 @@ rcloud.update.notebook <- function(id, content, is.current = TRUE) {
 # Some intelligent parsing account for basics like /solr/notebook and /solr/notebook/ is essentially the same thing
 # Using httr::parse_url
 
-.solr.post <- function(solr.url=getConf("solr.url"),data,solr.auth.user=getConf("solr.auth.user"),solr.auth.pwd=getConf("solr.auth.pwd")) {
+.solr.post <- function(data,solr.url=getConf("solr.url"),solr.auth.user=getConf("solr.auth.user"),solr.auth.pwd=getConf("solr.auth.pwd")) {
   solr.post.url <- httr::parse_url(solr.url)
   solr.post.url$path <- paste(solr.post.url$path,"update?commit=true",sep="/")
   if(is.null(solr.auth.user)){
@@ -371,7 +371,7 @@ rcloud.update.notebook <- function(id, content, is.current = TRUE) {
   }
 }
 
-.solr.get <- function(solr.url=getConf("solr.url"),query,solr.auth.user=getConf("solr.auth.user"),solr.auth.pwd=getConf("solr.auth.pwd")){
+.solr.get <- function(query,solr.url=getConf("solr.url"),solr.auth.user=getConf("solr.auth.user"),solr.auth.pwd=getConf("solr.auth.pwd")){
   solr.get.url <- httr::parse_url(solr.url)
   solr.get.url$path <- paste(solr.get.url$path,"select",sep="/")
   solr.get.url$query <- query

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -361,41 +361,28 @@ rcloud.update.notebook <- function(id, content, is.current = TRUE) {
 # Some intelligent parsing account for basics like /solr/notebook and /solr/notebook/ is essentially the same thing
 # Using httr::parse_url
 
-.solr.post <- function(data) {
-  solr.post.url <- httr::parse_url(getConf("solr.url"))
-  if(hasConf('solr.authkey')){
-  solr.post.url$path <- paste(solr.post.url$path,"secureupdate?commit=true",sep="/")
-  } else {
-    solr.post.url$path <- paste(solr.post.url$path,"update?commit=true",sep="/")
-  }
-  httr::POST(build_url(solr.post.url) , body = paste("[",data,"]",sep=''),content_type_json(),accept_json() ,add_headers("auth-key"=getConf("solr.authkey")))
+.solr.post <- function(solr.url=getConf("solr.url"),data,solr.auth.user=getConf("solr.auth.user"),solr.auth.pwd=getConf("solr.auth.pwd")) {
+  solr.post.url <- httr::parse_url(solr.url)
+  solr.post.url$path <- paste(solr.post.url$path,"update?commit=true",sep="/")
+  httr::POST(build_url(solr.post.url) , body = paste("[",data,"]",sep=''),content_type_json(),accept_json() , authenticate(solr.auth.user,solr.auth.pwd))
 }
 
-.solr.get <- function(query){
-  solr.get.url <- httr::parse_url(getConf("solr.url"))
-  solr.authkey <- getConf('solr.authkey')
-  if(hasConf('solr.authkey')){
-  solr.get.url$path <- paste(solr.get.url$path,"secureselect",sep="/")
-  } else {
-    solr.get.url$path <- paste(solr.get.url$path,"select",sep="/")
-  }
-  ## query ID to see if it has existing comments
+.solr.get <- function(solr.url=getConf("solr.url"),query,solr.auth.user=getConf("solr.auth.user"),solr.auth.pwd=getConf("solr.auth.pwd")){
+  solr.get.url <- httr::parse_url(solr.url)
+  solr.get.url$path <- paste(solr.get.url$path,"select",sep="/")
   solr.get.url$query <- query
-  solr.res <- httr::GET(build_url(solr.get.url),accept_json(),add_headers("auth-key"=as.character(solr.authkey)))
+  # https://cwiki.apache.org/confluence/display/solr/Response+Writers
+  solr.get.url$query$wt<-"json"
+  # DELETE ME
+  print(build_url(solr.get.url))
+  solr.res <- httr::GET(build_url(solr.get.url),content_type_json(),accept_json(),authenticate(solr.auth.user,solr.auth.pwd))
   solr.res <- fromJSON(content(solr.res, "parsed"))
   return(solr.res)
-}
+} 
 
 update.solr <- function(notebook, starcount){
   solr.post.url <- getConf("solr.url")
   if (is.null(solr.post.url)) stop("solr configuration not enabled")
-  solr.post.url <- httr::parse_url(solr.post.url)
-  if(hasConf('solr.authkey')){
-    solr.post.url$path <- paste(solr.post.url$path,"secureupdate?commit=true",sep="/")
-    } else {
-      solr.post.url$path <- paste(solr.post.url$path,"update?commit=true",sep="/")
-    }
-
 
   ## FIXME: gracefully handle unavailability
   content.files <- notebook$content$files
@@ -425,7 +412,7 @@ update.solr <- function(notebook, starcount){
     content.files <- toJSON(content.files)
     metadata.list$content$set <- content.files
     completedata <- toJSON(metadata.list)
-    .solr.post(completedata)
+    .solr.post(data=completedata)
   }
 }
 
@@ -433,17 +420,15 @@ rcloud.search <-function(query, all_sources, sortby, orderby, start, pagesize) {
   url <- getConf("solr.url")
   if (is.null(url)) stop("solr is not enabled")
   ## FIXME: shouldn't we URL-encode the query?!?
-  solr.query <- paste0("q=",query,"&start=",start,"&rows=",pagesize,"&wt=json&indent=true&fl=description,id,user,updated_at,starcount&hl=true&hl.preserveMulti=true&hl.fl=content,comments&hl.fragsize=0&hl.maxAnalyzedChars=-1&sort=",sortby,"+",orderby)
-  query <- function(solr.url,source='',solr.authkey=NA) {
-    solr.get.url <- httr::parse_url(solr.url)
-    if(!(is.na(solr.authkey))){
-      solr.get.url$path <- paste(solr.get.url$path,"secureselect",sep="/")
-      } else {
-        solr.get.url$path <- paste(solr.get.url$path,"select",sep="/")
-      }
-      solr.get.url$query <- solr.query
-      solr.res <- httr::GET(build_url(solr.get.url),accept_json(),add_headers("auth-key"=as.character(solr.authkey)))
-      solr.res <- fromJSON(content(solr.res, "parsed")) 
+  solr.query <- list(q=query,start=start,rows=pagesize,indent="true",hl="true",hl.preserveMulti="true",hl.fragsize=0,hl.maxAnalyzedChars=-1
+    ,fl="description,id,user,updated_at,starcount",hl.fl="content,comments",sort=paste(sortby,orderby))
+  query <- function(solr.url,source='',solr.auth.user=NA,solr.auth.pwd=NA) {
+      #solr.res <- httr::GET(build_url(solr.get.url),accept_json(),add_headers("auth-key"=as.character(solr.authkey)))
+      solr.res <- .solr.get(solr.url=solr.url,query=solr.query,solr.auth.user=as.character(solr.auth.user),solr.auth.pwd=as.character(solr.auth.pwd))
+      if (!is.null(solr.res$error)) stop(paste0(solr.res$error$code,": ",solr.res$error$msg))
+      #return(solr.res)
+      #solr.res <- fromJSON(content(solr.res, "parsed")) 
+      print ("Check 2")
       response.docs <- solr.res$response$docs
       count <- solr.res$response$numFound
       rows <- solr.res$params$rows
@@ -531,17 +516,16 @@ rcloud.search <-function(query, all_sources, sortby, orderby, start, pagesize) {
                                       } else
                                       return(c("error",solr.res$error$msg))
                                     }
-
-                                    solr.authKey <- getConf('solr.authkey')
-                                    if(is.null(solr.authKey))solr.authKey=NA 
+                                    solr.auth.user=getConf("solr.auth.user")
+                                    solr.auth.pwd=getConf("solr.auth.pwd")
                                     if (isTRUE(all_sources)) {
-                                      main <- query(url,solr.authkey=c('solr.authkey'=solr.authKey))
+                                      main <- query(url,solr.auth.user=solr.auth.user,solr.auth.pwd=solr.auth.pwd)
                                       l <- lapply(.session$gist.sources.conf, function(src)
-                                       if ("solr.url" %in% names(src)) query(src['solr.url'], src['gist.source'],src['solr.authkey']) 
+                                       if ("solr.url" %in% names(src)) query(src['solr.url'], src['gist.source'],src['solr.auth.user'],src['solr.auth.pwd']) 
                                        else character(0))
                                       unlist(c(list(main), l))
                                     } 
-                                    else query(url,solr.authkey=c('solr.authkey'=solr.authKey))
+                                    else query(url,solr.auth.user=solr.auth.user,solr.auth.pwd=solr.auth.pwd)
                                   }
 
                                   stitch.search.result <- function(splitted, type,k) {

--- a/rcloud.support/R/setup.R
+++ b/rcloud.support/R/setup.R
@@ -469,5 +469,5 @@ start.rcloud.anonymously <- function(...)
 .wipe.secrets <- function() {
     ## Redis is already dealt with since we scrub it right when we use it,
     ## but gist back-ends are separate
-    scrubConf(c("github.client.secret", "github.client.id"))
+    scrubConf(c("github.client.secret", "github.client.id","solr.auth.user","solr.auth.pwd"))
 }


### PR DESCRIPTION
Based on Solr 5 release. Basic Authentication is a part of the setup for organization to apply ACL

Introducing two new configuration parameters. 
solr.auth.user
solr.auth.pwd

The commit has been tested on my side with the three scenarios
1) Parent Solr with Basic Auth and remote SOLR with unsecured SOLR
2) Parent Solr unsecured and remote SOLR with Basic Auth
3) Unsecured Solr as parent and remote

Modules tested:
1) Comments (modify/delete/create)
2) Search (update/search notebooks)