### PR TITLE
Proposed fix for #1852

### DIFF
--- a/htdocs/css/bootstrap-rcloud-tweaks.css
+++ b/htdocs/css/bootstrap-rcloud-tweaks.css
@@ -493,6 +493,7 @@ ul.recent-notebooks-list li a {
 
 .jqtree-element .jqtree-title.jqtree_common {
     word-break: break-all;
+    display: inline-block;
 }
 
 #settings-body-wrapper.panel-body {


### PR DESCRIPTION
Fix for #1852, with the caveat that the info is displaced for long notebook titles.

![1852](https://cloud.githubusercontent.com/assets/2493614/13853152/5813ed48-ec5d-11e5-85b4-ffdd430c27d7.png)
