### PR TITLE
fix for firefox long names

### DIFF
--- a/htdocs/css/bootstrap-rcloud-tweaks.css
+++ b/htdocs/css/bootstrap-rcloud-tweaks.css
@@ -294,9 +294,13 @@ td {
     padding: 5px 15px;
 }
 
+.popover {
+    max-width: 350px;
+}
+
 .popover-title {
     padding: 4px 10px;
-    word-break: break-word;
+    word-break: break-all;
 }
 
 .popover-content {

--- a/htdocs/css/edit.css
+++ b/htdocs/css/edit.css
@@ -644,7 +644,7 @@ ul.jqtree-tree .jqtree-title.foreign-notebook {
 
 #search-results-pagination {
     display:table-row;
-    text-align:center
+    text-align:center;
     display: none;
 }
 

--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -278,7 +278,7 @@
       <div class="tab-content">
         <!-- first tab -->
         <div class="tab-pane active inner-tab" id="notebook-tab">
-          <div class="row sec" style="word-break:break-word;">
+          <div class="row sec" style="word-break:break-all;">
             {{notebookFullName}}
           </div>
           <div class="row sec">


### PR DESCRIPTION
introduced `word-break:break-all` into the mix:

![image](https://cloud.githubusercontent.com/assets/2493614/13953518/3ea52220-f034-11e5-972e-abb47cd1d163.png)

![image](https://cloud.githubusercontent.com/assets/2493614/13953542/55ba0700-f034-11e5-81c8-120740b25bb7.png)
