### PR TITLE
categorize shortcut keys by readonly

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -113,6 +113,7 @@ RCloud.UI.init = function() {
             ['command', 's'],
             ['ctrl', 's']
         ],
+        modes: ['writeable'],
         action: function() { if(RCloud.UI.navbar.get('save_notebook')) { shell.save_notebook(); } }
     }, {
         category: 'Notebook Management',
@@ -122,6 +123,7 @@ RCloud.UI.init = function() {
             ['command', 'a'],
             ['ctrl', 'a']
         ],
+        modes: ['writeable'],
         action: function() {
             var selection = window.getSelection();
             selection.removeAllRanges();
@@ -138,6 +140,7 @@ RCloud.UI.init = function() {
             ['command', 'z'],
             ['ctrl', 'z']
         ],
+        modes: ['writeable'],
         action: function() { editor.step_history_undo(); }
     }, {
         category: 'Notebook Management',
@@ -148,6 +151,7 @@ RCloud.UI.init = function() {
             //['ctrl', 'shift', 'z'],
             ['command', 'shift', 'z']
         ],
+        modes: ['writeable'],
         action: function() { editor.step_history_redo(); }
     }]);
 
@@ -159,6 +163,7 @@ RCloud.UI.init = function() {
         keys: [
             ['del']
         ],
+        modes: ['writeable'],
         action: function() { shell.notebook.controller.remove_selected_cells(); }
     }, {
         category: 'Cell Management',
@@ -168,6 +173,7 @@ RCloud.UI.init = function() {
             ['ctrl', 'shift', 'i'],
             ['command', 'shift', 'i']
         ],
+        modes: ['writeable'],
         action: function() { shell.notebook.controller.invert_selected_cells(); }
     }, {
         category: 'Cell Management',
@@ -177,6 +183,7 @@ RCloud.UI.init = function() {
             ['ctrl', 'k'],
             ['command', 'k']
         ],
+        modes: ['writeable'],
         action: function() { shell.notebook.controller.crop_cells(); }
     }]);
 
@@ -188,6 +195,7 @@ RCloud.UI.init = function() {
         keys: [
             ['?']
         ],
+        modes: ['writeable', 'readonly'],
         action: function() { RCloud.UI.shortcut_dialog.show(); }
     }]);
 

--- a/htdocs/js/ui/shortcut_dialog.js
+++ b/htdocs/js/ui/shortcut_dialog.js
@@ -22,43 +22,41 @@ RCloud.UI.shortcut_dialog = (function() {
                 $("body").append(shortcut_dialog_);
             } 
 
-            if(!content_ || RCloud.UI.shortcut_manager.shortcuts_changed()) {
-                shortcuts_by_category_ = RCloud.UI.shortcut_manager.get_registered_shortcuts_by_category([
-                    'General',
-                    'Notebook Management',
-                    'Cell Management']);
+            shortcuts_by_category_ = RCloud.UI.shortcut_manager.get_registered_shortcuts_by_category([
+                'General',
+                'Notebook Management',
+                'Cell Management']);
 
-                content_ = '';
+            content_ = '';
 
-                _.each(shortcuts_by_category_, function(group) {
+            _.each(shortcuts_by_category_, function(group) {
 
-                    content_ += '<div class="category">';
-                    content_ += '<h3>' + group.category + '</h3>';
-                    content_ += '<table>';
+                content_ += '<div class="category">';
+                content_ += '<h3>' + group.category + '</h3>';
+                content_ += '<table>';
 
-                    _.each(group.shortcuts, function(shortcut) {
+                _.each(group.shortcuts, function(shortcut) {
 
-                        var keys_markup = []; 
-                        _.each(shortcut.keys, function(keys) {
-                            keys_markup.push('<kbd>' + keys.join(' ') + '</kbd>');
-                        });
-
-                        content_ += '<tr>';
-                        content_ += '<td>';
-                        content_ += keys_markup.join(' / ');
-                        content_ += '</td>';
-                        content_ += '<td>';
-                        content_ += shortcut.description;
-                        content_ += '</td>';
-                        content_ += '</tr>';
+                    var keys_markup = []; 
+                    _.each(shortcut.keys, function(keys) {
+                        keys_markup.push('<kbd>' + keys.join(' ') + '</kbd>');
                     });
 
-                    content_ += '</table>';
-                    content_ += '</div>';
+                    content_ += '<tr>';
+                    content_ += '<td>';
+                    content_ += keys_markup.join(' / ');
+                    content_ += '</td>';
+                    content_ += '<td>';
+                    content_ += shortcut.description;
+                    content_ += '</td>';
+                    content_ += '</tr>';
                 });
 
-                $('#shortcut-dialog .modal-body').html(content_);
-            }
+                content_ += '</table>';
+                content_ += '</div>';
+            });
+
+            $('#shortcut-dialog .modal-body').html(content_);
             
             shortcut_dialog_.modal({ 
                 keyboard: false 

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -1,7 +1,10 @@
 RCloud.UI.shortcut_manager = (function() {
 
-    var extension_, 
-        shortcuts_changed = false;
+    var extension_;
+
+    function is_active(shortcut) {
+        return _.contains(shortcut.modes, shell.notebook.model.read_only() ? 'readonly' : 'writeable');
+    }
 
     function convert_extension(shortcuts) {
         var shortcuts_to_add, obj = {};
@@ -88,8 +91,14 @@ RCloud.UI.shortcut_manager = (function() {
                         shortcut_to_add.create = function() { 
                             _.each(shortcut_to_add.key_bindings, function(binding) {
                                 window.Mousetrap(document.querySelector('body')).bind(binding, function(e) { 
-                                    e.preventDefault(); 
-                                    shortcut.action();
+
+                                    if(!is_active(shortcut_to_add)) {
+                                        return;
+                                    } else {
+                                        e.preventDefault(); 
+                                        shortcut.action();
+                                    }
+
                                 });
                             });
                         }
@@ -136,7 +145,6 @@ RCloud.UI.shortcut_manager = (function() {
         add: function(s) {
             if(extension_) {
                 extension_.add(convert_extension(s));
-                shortcuts_changed = true;
             }
 
             return this;
@@ -146,18 +154,14 @@ RCloud.UI.shortcut_manager = (function() {
                 extension_.create('all');
             }
         },
-        shortcuts_changed: function() {
-            return shortcuts_changed;
-        },
         get_registered_shortcuts_by_category: function(sort_items) {
-            shortcuts_changed = false;
-
-            console.log();
 
             var rank = _.map(sort_items, (function(item, index) { return { key: item, value: index + 1 }}));
             rank = _.object(_.pluck(rank, 'key'), _.pluck(rank, 'value'));   
   
-            return _.sortBy(_.map(_.chain(extension_.sections.all.entries).groupBy('category').value(), function(item, key) {
+            var available_shortcuts = _.filter(extension_.sections.all.entries, function(s) { return is_active(s); });
+
+            return _.sortBy(_.map(_.chain(available_shortcuts).groupBy('category').value(), function(item, key) {
                 return { category: key, shortcuts: item }
             }), function(group) {
                 return rank[group.category];


### PR DESCRIPTION
I use `shell.notebook.model.read_only()` to interpret the meaning of the modes.