### PR TITLE
Only show 'Shortcuts Help' dialog when no other dialog is visible.

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -197,7 +197,11 @@ RCloud.UI.init = function() {
             ['?']
         ],
         modes: ['writeable', 'readonly'],
-        action: function() { RCloud.UI.shortcut_dialog.show(); }
+        action: function() { 
+            if(!$('.modal').is(':visible')) {
+                RCloud.UI.shortcut_dialog.show(); 
+            }
+        }
     }, {
         category: 'General',
         id: 'close_modal',


### PR DESCRIPTION
Simple fix testing for `.modal` visibility.