### PR TITLE
Ignore keyboard shortcuts in editable items

### DIFF
--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -125,12 +125,7 @@ RCloud.UI.shortcut_manager = (function() {
             // based on https://craig.is/killing/mice#api.stopCallback
             window.Mousetrap.prototype.stopCallback = function(e, element, combo) {
 
-                // if the element has the class "mousetrap" then no need to stop
-                //if ((' ' + element.className + ' ').indexOf(' mousetrap ') > -1) {
-                //    return false;
-                //}
-
-                if([' mousetrap ', ' ace_text-input '].indexOf(' ' + element.className + ' ')) {
+                if([' mousetrap ', ' ace_text-input '].indexOf(' ' + element.className + ' ') > -1) {
                     return false;
                 }
 


### PR DESCRIPTION
Sorry. I made a [schoolboy error](https://en.wiktionary.org/wiki/schoolboy_error).

The first if statement's condition was incorrect in the `Mousetrap.prototype.stopCallback` function and was no doubt causing all sorts of issues (including this one.)