### PR TITLE
Crop and delete cell buttons are now enabled appropriately

### DIFF
--- a/htdocs/js/ui/selection_bar.js
+++ b/htdocs/js/ui/selection_bar.js
@@ -19,6 +19,7 @@ RCloud.UI.selection_bar = (function() {
             $selection_checkbox = $selection_bar.find('.cell-selection input[type="checkbox"]');
             $dropdown_toggle = $selection_bar.find('.dropdown-toggle');
             $delete_button = $selection_bar.find('#selection-bar-delete');
+            $crop_button = $selection_bar.find('#selection-bar-crop');
             $cell_selection = $selection_bar.find('.cell-selection');
 
             $selection_bar
@@ -66,7 +67,7 @@ RCloud.UI.selection_bar = (function() {
                 'disabled' : cell_count === 0
             });
 
-            _.each([$delete_button, $dropdown_toggle, $cell_selection], function(el) { 
+            _.each([$delete_button, $crop_button, $dropdown_toggle, $cell_selection], function(el) { 
                 el[cell_count ? 'removeClass' : 'addClass']('disabled');  
             });
 

--- a/htdocs/js/ui/selection_bar.js
+++ b/htdocs/js/ui/selection_bar.js
@@ -67,9 +67,14 @@ RCloud.UI.selection_bar = (function() {
                 'disabled' : cell_count === 0
             });
 
-            _.each([$delete_button, $crop_button, $dropdown_toggle, $cell_selection], function(el) { 
+            // checkbox/dropdown enabled status based on cell count:
+            _.each([$dropdown_toggle, $cell_selection], function(el) { 
                 el[cell_count ? 'removeClass' : 'addClass']('disabled');  
             });
+
+            // delete/crop buttons' enabled status based on selection count:
+            $delete_button[selected_count ? 'removeClass' : 'addClass']('disabled');
+            $crop_button[selected_count && selected_count !== cell_count ? 'removeClass' : 'addClass']('disabled');
 
             $partial_indicator[selected_count !== cell_count && selected_count !== 0 ? 'show' : 'hide']();     
 


### PR DESCRIPTION
- Delete is only enabled when at least 1 cell is selected.
- Crop is only enabled when there is at least 1 selected cell **and** there is at least 1 non-selected cell. This is because crop deletes non-selected cells and we don't want it deleting all (when none are selected, as described in #1904.)
