### PR TITLE
ESCaping after notebook title node edit removes focus (for real)

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -977,6 +977,13 @@ var editor = function () {
         var element = $li.find('.jqtree-element'),
             title = element.find('.jqtree-title');
         title.css('color', node.color);
+
+        title.on('keydown', function(e) {
+            if(e.keyCode === 27) {
+                window.getSelection().removeAllRanges();
+            }
+        });
+
         if(node.gistname) {
             if(node.source)
                 title.addClass('foreign-notebook');


### PR DESCRIPTION
This should fix the editing titles part of issue #1831. 

Setting focus on something else didn't work, so I used `window.getSelection().removeAllRanges()`.

