### PR TITLE
Import Notebook from File - Import button is enabled appropriately

### DIFF
--- a/htdocs/js/ui/import_export.js
+++ b/htdocs/js/ui/import_export.js
@@ -145,8 +145,17 @@ RCloud.UI.import_export = (function() {
                             }
                             var body = $('<div class="container"/>');
                             var file_select = $('<input type="file" id="notebook-file-upload" size="50"></input>');
-                            file_select.click(function() { ui_utils.disable_bs_button(import_button); })
-                                .change(function() { do_upload(file_select[0].files[0]); });
+
+                            file_select
+                                .click(function() { 
+                                    ui_utils.disable_bs_button(import_button); 
+                                    [notebook_desc, notebook_status].forEach(function(el) { el.hide(); });
+                                    file_select.val(null);
+                                })
+                                .change(function() { 
+                                    do_upload(file_select[0].files[0]); 
+                                });
+
                             notebook_status = $('<span />');
                             notebook_status.append(notebook_status);
                             var notebook_desc = $('<span>Notebook description: </span>');


### PR DESCRIPTION
This is a fix for issue #1840.

I gave the `file_select` event handler code a little more room to breathe, and added a couple of lines to the click handler.

If the user uploads the same file a successive time, the `change` handler is not invoked, so the 'Import' button, disabled by the `click` handler, was not being enabled as a result of `do_upload` success.

On click, the `file_select` value is set to null, meaning that any successful file upload, same or not, is interpreted as a change.

A caveat is that if the user clicks `cancel` on the upload, any previous file will have been cleared.