### PR TITLE
? can now be typed where required, ESC closes dialogs when focus is in field

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -197,7 +197,7 @@ RCloud.UI.init = function() {
             ['?']
         ],
         modes: ['writeable', 'readonly'],
-        action: function() { 
+        action: function(e) {
             if(!$('.modal').is(':visible')) {
                 RCloud.UI.shortcut_dialog.show(); 
             }

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -209,6 +209,7 @@ RCloud.UI.init = function() {
         keys: [
             ['esc']
         ],
+        global: true,
         action: function() { $('.modal').modal('hide'); }
     }]);
 

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -92,15 +92,21 @@ RCloud.UI.shortcut_manager = (function() {
                     else {
                         shortcut_to_add.create = function() { 
                             _.each(shortcut_to_add.key_bindings, function(binding) {
-                                window.Mousetrap(document.querySelector('body')).bind(binding, function(e) { 
 
+                                var func_to_bind = function(e) {
                                     if(!is_active(shortcut_to_add)) {
                                         return;
                                     } else {
                                         e.preventDefault();
                                         shortcut.action();
                                     }
-                                });
+                                };
+
+                                if(shortcut_to_add.global) {
+                                    window.Mousetrap.bindGlobal(binding, func_to_bind);
+                                } else {
+                                    window.Mousetrap(document.querySelector('body')).bind(binding, func_to_bind);    
+                                }
                             });
                         }
                     }
@@ -124,7 +130,6 @@ RCloud.UI.shortcut_manager = (function() {
 
             // based on https://craig.is/killing/mice#api.stopCallback
             window.Mousetrap.prototype.stopCallback = function(e, element, combo) {
-
 
                 var search_values = ['mousetrap', 'ace_text-input'];
 

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -98,7 +98,7 @@ RCloud.UI.shortcut_manager = (function() {
                                         return;
                                     } else {
                                         e.preventDefault();
-                                        shortcut.action();
+                                        shortcut.action(e);
                                     }
                                 };
 
@@ -131,14 +131,18 @@ RCloud.UI.shortcut_manager = (function() {
             // based on https://craig.is/killing/mice#api.stopCallback
             window.Mousetrap.prototype.stopCallback = function(e, element, combo) {
 
-                var search_values = ['mousetrap', 'ace_text-input'];
+                // this only executes if the shortcut is *not* defined as global:
+                var search_values = ['mousetrap', 'ace_text-input'],
+                    is_text = !e.metaKey && !e.ctrlKey && !e.altKey;
 
+                // allow the event to be handled:
                 for(var loop = 0; loop < search_values.length; loop++) {
-                    if((' ' + element.className + ' ').indexOf(' ' + search_values[loop] + ' ') > -1) {
+                    if((' ' + element.className + ' ').indexOf(' ' + search_values[loop] + ' ') > -1 && !is_text) {
                         return false;
                     }
                 }
 
+                // prevent on form fields and content editables:
                 return (element.tagName == 'INPUT' && element.type !== 'checkbox') || 
                        element.tagName == 'SELECT' || 
                        element.tagName == 'TEXTAREA' || 

--- a/htdocs/lib/js/mousetrap-global-bind.min.js
+++ b/htdocs/lib/js/mousetrap-global-bind.min.js
@@ -1,0 +1,1 @@
+(function(a){var c={},d=a.prototype.stopCallback;a.prototype.stopCallback=function(e,b,a,f){return this.paused?!0:c[a]||c[f]?!1:d.call(this,e,b,a)};a.prototype.bindGlobal=function(a,b,d){this.bind(a,b,d);if(a instanceof Array)for(b=0;b<a.length;b++)c[a[b]]=!0;else c[a]=!0};a.init()})(Mousetrap);

--- a/htdocs/lib/js/require-common.js
+++ b/htdocs/lib/js/require-common.js
@@ -40,7 +40,8 @@ var common_deps = [
     "bootstrap", "peg-0.6.2.min",
     "rserve", "tree.jquery", "FileSaver",
     "css_browser_selector",
-    "mousetrap.min"
+    "mousetrap.min",
+    "mousetrap-global-bind.min"
 ];
 
 function start_require(deps) {


### PR DESCRIPTION
By default, mousetrap prevents shortcuts being invoked in form fields. It runs the shortcut if the focus element has a class of `mousetrap`.  In a previous commit, I added the `ace_text-input` class to this check.

I have added an optional 'global' modifier to a shortcut so that it is always invoked regardless of focus element. This applies to the `esc` shortcut (#1928).

I have also modified the `window.Mousetrap.prototype.stopCallback` function so that it checks for 'text' entry (no `ctrl`, `meta` or `alt` modifiers) so currently, this applies to shortcuts invoked using `delete` and `backspace`. It only invokes the shortcut if it isn't text, and thus fixing #1931.





