### PR TITLE
Discover page notebook title wrap fix for Firefox

### DIFF
--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -99,11 +99,8 @@ progress::-webkit-progress-value {
 .grid-item h1{
     font-size: 17px;
     margin: 0;
-    /* firefox */
     white-space: pre-wrap;
     word-break: break-all;
-    /* chrome */
-    word-break: break-word;
 }
 
 .grid-item h2 {

--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -99,6 +99,10 @@ progress::-webkit-progress-value {
 .grid-item h1{
     font-size: 17px;
     margin: 0;
+    /* firefox */
+    white-space: pre-wrap;
+    word-break: break-all;
+    /* chrome */
     word-break: break-word;
 }
 


### PR DESCRIPTION
Introduced firefox-friendly CSS (it ignored the existing `word-break: break-word` property/value.)