### PR TITLE
Beautification of find/replace dialog

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -63,6 +63,30 @@
   </span>
 </script>
 
+<script type="text/template" id="find-in-notebook-snippet">
+
+  <div id="find-dialog">
+    <form id="find-form">
+      <i class="icon-search"></i>
+      <div class="find">
+        <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
+        <button id="find-last" class="btn">Previous</button>
+        <button id="find-next" class="btn btn-primary">Next</button>
+      </div>
+      <div class="replace" style="display:none">
+        <input type=text id="replace-input" class="form-control-ext mousetrap" placeholder="Replace"></input>
+        <button id="replace" class="btn">Replace</button>
+        <button id="replace-all" class="btn">Replace All</button>
+      </div>
+    </form>
+    <span id="find-close"><i class="icon-remove"></i></span>
+  </div>
+
+
+  
+
+</script>
+
 <script type="text/html" id="search-snippet">
   <div class="panel-body" style="padding-bottom: 0;padding-top:3px">
     <div id="search-wrapper" class="widget-vsize"> <!-- only for sizing -->

--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -64,14 +64,13 @@
 </script>
 
 <script type="text/template" id="find-in-notebook-snippet">
-
   <div id="find-dialog">
     <form id="find-form">
       <i class="icon-search"></i>
       <div class="find">
         <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
-        <button id="find-last" class="btn">Previous</button>
-        <button id="find-next" class="btn btn-primary">Next</button>
+        <button id="find-last" class="btn"><i class="icon-arrow-left"></i></button>
+        <button id="find-next" class="btn btn-primary"><i class="icon-arrow-right"></i></button>
       </div>
       <div class="replace" style="display:none">
         <input type=text id="replace-input" class="form-control-ext mousetrap" placeholder="Replace"></input>
@@ -79,12 +78,8 @@
         <button id="replace-all" class="btn">Replace All</button>
       </div>
     </form>
-    <span id="find-close"><i class="icon-remove"></i></span>
+    <a id="find-close" href="javascript:void(0)"><i class="icon-remove"></i></a>
   </div>
-
-
-  
-
 </script>
 
 <script type="text/html" id="search-snippet">

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -1,12 +1,36 @@
 RCloud.UI.find_replace = (function() {
     var find_dialog_ = null, regex_,
-        find_desc_, find_input_, replace_desc_, replace_input_, replace_stuff_,
-        find_next_, find_last_, replace_next_, replace_all_,
+        find_form_,
+        /*find_desc_,*/ find_input_, /*replace_desc_,*/ replace_input_, replace_stuff_,
+        find_next_, find_last_, replace_next_, replace_all_, close_,
         shown_ = false, replace_mode_ = false,
         find_cycle_ = null, replace_cycle_ = null,
         matches_ = [], active_match_;
     function toggle_find_replace(replace) {
         if(!find_dialog_) {
+
+            var template = _.template(
+                $("#find-in-notebook-snippet").html()
+            );
+
+            var markup = $(template({
+                //notebooks: recent_notebooks
+            }));
+
+            $('#middle-column').prepend(markup);
+
+            find_dialog_ = $(markup.get(0));
+            find_form_ = markup.find('#find-form');
+            find_input_ = markup.find('#find-input');
+            find_next_ = markup.find('#find-next');
+            find_last_ = markup.find('#find-last');
+            replace_input_ = markup.find('#replace-input');
+            replace_next_ = markup.find('#replace');
+            replace_all_ = markup.find('#replace-all');
+            replace_stuff_ = markup.find('.replace');
+            close_ = markup.find('#find-close');
+
+            /*
             find_dialog_ = $('<div id="find-dialog"></div>');
             var find_form = $('<form id="find-form"></form>');
             find_desc_ = $('<label id="find-label" for="find-input"><span>Find</span></label>');
@@ -24,7 +48,7 @@ RCloud.UI.find_replace = (function() {
                              replace_desc_.append(replace_input_), replace_next_, replace_all_);
             find_dialog_.append(find_form);
             $('#middle-column').prepend(find_dialog_);
-
+            */
             find_input_.on('input', function(e) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -105,7 +129,7 @@ RCloud.UI.find_replace = (function() {
             find_input_.keydown(click_find_next);
             replace_input_.keydown(click_find_next);
 
-            find_form.keydown(function(e) {
+            find_form_.keydown(function(e) {
                 switch(e.keyCode) {
                 case $.ui.keyCode.TAB:
                     e.preventDefault();
@@ -125,13 +149,13 @@ RCloud.UI.find_replace = (function() {
                 return undefined;
             });
 
-            find_form.find('input').focus(function() {
+            find_form_.find('input').focus(function() {
                 window.setTimeout(function() {
                     this.select();
                 }.bind(this), 0);
             });
 
-            close.click(function() {
+            close_.click(function() {
                 hide_dialog();
             });
         }

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -269,7 +269,6 @@ RCloud.UI.find_replace = (function() {
     }
     var result = {
         init: function() {
-
             RCloud.UI.shortcut_manager.add([{
                 category: 'Notebook Management',
                 id: 'notebook_find',

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -9,13 +9,9 @@ RCloud.UI.find_replace = (function() {
     function toggle_find_replace(replace) {
         if(!find_dialog_) {
 
-            var template = _.template(
+            var markup = $(_.template(
                 $("#find-in-notebook-snippet").html()
-            );
-
-            var markup = $(template({
-                //notebooks: recent_notebooks
-            }));
+            )({}));
 
             $('#middle-column').prepend(markup);
 
@@ -46,6 +42,7 @@ RCloud.UI.find_replace = (function() {
                     active_match_ = 0;
                 active_transition('activate');
             }
+
             find_next_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -30,25 +30,6 @@ RCloud.UI.find_replace = (function() {
             replace_stuff_ = markup.find('.replace');
             close_ = markup.find('#find-close');
 
-            /*
-            find_dialog_ = $('<div id="find-dialog"></div>');
-            var find_form = $('<form id="find-form"></form>');
-            find_desc_ = $('<label id="find-label" for="find-input"><span>Find</span></label>');
-            find_input_ = $('<input type=text id="find-input" class="form-control-ext mousetrap"></input>');
-            find_next_ = $('<button id="find-next" class="btn btn-primary">Next</button>');
-            find_last_ = $('<button id="find-last" class="btn">Previous</button>');
-            var replace_break = $('<br/>');
-            replace_desc_ = $('<label id="replace-label" for="replace-input"><span>Replace</span></label>');
-            replace_input_ = $('<input type=text id="replace-input" class="form-control-ext mousetrap"></input>');
-            replace_next_ = $('<button id="replace" class="btn">Replace</button>');
-            replace_all_ = $('<button id="replace-all" class="btn">Replace All</button>');
-            replace_stuff_ = replace_break.add(replace_desc_).add(replace_input_).add(replace_next_).add(replace_all_);
-            var close = $('<span id="find-close"><i class="icon-remove"></i></span>');
-            find_form.append(find_desc_.append(find_input_), find_next_, find_last_, close, replace_break,
-                             replace_desc_.append(replace_input_), replace_next_, replace_all_);
-            find_dialog_.append(find_form);
-            $('#middle-column').prepend(find_dialog_);
-            */
             find_input_.on('input', function(e) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -311,30 +292,6 @@ RCloud.UI.find_replace = (function() {
                 ],
                 action: function() { toggle_find_replace(!shell.notebook.model.read_only()); }
             }]);
-
-
-/*
-            document.addEventListener("keydown", function(e) {
-                var action;
-                if (ui_utils.is_a_mac() && e.keyCode == 70 && e.metaKey) { // cmd-F / cmd-opt-F
-                    if(e.shiftKey)
-                        return; // don't capture Full Screen
-                    action = e.altKey ? 'replace' : 'find';
-                }
-                else if(!ui_utils.is_a_mac() && e.keyCode == 70 && e.ctrlKey) // ctrl-F
-                    action = 'find';
-                else if(!ui_utils.is_a_mac() && e.keyCode == 72 && e.ctrlKey) // ctrl-H
-                    action = 'replace';
-                if(action) {
-                    // do not allow replace in view mode or read-only
-                    if(shell.notebook.model.read_only())
-                        action = 'find';
-                    e.preventDefault();
-                    toggle_find_replace(action === 'replace');
-                }
-            });
-*/
-
         }
     };
     return result;

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -315,7 +315,6 @@ td {
     word-wrap: break-word;
 }
 
-
 #find-dialog {
     
     position: relative;
@@ -363,40 +362,7 @@ td {
             padding: 3px 10px;
         }
     }
-
 }
-
-
-/*
-#find-dialog .btn {
-    margin-left: 7px;
-    padding: 3px 12px;
-}
-
-#find-dialog label span {
-    margin-left: 7px;
-    margin-right: 5px;
-}
-
-#find-dialog form {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-}
-
-#replace-label span, #find-label span {
-    display: inline-block;
-    width: 50px;
-}
-
-#find-dialog input {
-    width: 160px
-}
-
-*/
-
-
-
-
 
 .find-highlight {
     background-color: yellow;
@@ -416,8 +382,6 @@ td {
 .ace_start.find-highlight {
     position: absolute;
 }
-
-
 
 .inner-tab {
       padding: 30px;

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -319,10 +319,11 @@ td {
 #find-dialog {
     
     position: relative;
-    padding: 6px;
 
     #find-form {
         margin-bottom: 0;
+        padding-bottom: 6px;
+        padding-left: 6px;
     }
 
     .icon-search {
@@ -351,9 +352,13 @@ td {
 
     .find, .replace {
         display: inline-block;
+        padding: 6px 6px 0 6px;
     }
 
     .replace {
+
+        margin-left: 18px;
+
         .btn {
             padding: 3px 10px;
         }

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -353,6 +353,12 @@ td {
         display: inline-block;
     }
 
+    .replace {
+        .btn {
+            padding: 3px 10px;
+        }
+    }
+
 }
 
 

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -315,6 +315,48 @@ td {
     word-wrap: break-word;
 }
 
+
+#find-dialog {
+    
+    position: relative;
+    padding: 6px;
+
+    #find-form {
+        margin-bottom: 0;
+    }
+
+    .icon-search {
+        font-size: 16px;
+        vertical-align: middle;
+    }
+
+    input {
+        width: 160px;
+    }
+
+    #find-close {
+        position: absolute;
+        cursor: pointer;
+        top: 10px;
+        right: 8px;
+        color: #777;
+        transition: color .2s linear;
+        font-size: 18px;
+
+        &:hover {
+            text-decoration: none;
+            color: #000;
+        }
+    }
+
+    .find, .replace {
+        display: inline-block;
+    }
+
+}
+
+
+/*
 #find-dialog .btn {
     margin-left: 7px;
     padding: 3px 12px;
@@ -330,14 +372,6 @@ td {
     margin-bottom: 0.5em;
 }
 
-#find-close {
-    float: right;
-    cursor: pointer;
-    position: relative;
-    top: 7;
-    right: 5;
-}
-
 #replace-label span, #find-label span {
     display: inline-block;
     width: 50px;
@@ -346,6 +380,12 @@ td {
 #find-dialog input {
     width: 160px
 }
+
+*/
+
+
+
+
 
 .find-highlight {
     background-color: yellow;

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -322,7 +322,7 @@ td {
 
     #find-form {
         margin-bottom: 0;
-        padding-bottom: 6px;
+        padding-bottom: 5px;
         padding-left: 6px;
     }
 


### PR DESCRIPTION
This attempts to address #1914.

I have implemented an underscore template in `edit.html` (0ec5c12) which makes working with the markup a little easier, and removes some boilerplate DOM manipulation from `find_replace.js`.

Other than that, it's pretty much visual styling. Hopefully it's prettier.