### PR TITLE
Shortcuts fixed (including CTRL + S) for 'Discover'

### DIFF
--- a/htdocs/discover.js
+++ b/htdocs/discover.js
@@ -26,7 +26,6 @@ function main() {
         shell.init();
         RCloud.UI.advanced_menu.init();
         RCloud.UI.menus.load();
-        RCloud.UI.shortcut_manager.load();
         notebook = getURLParameter("notebook");
         version = getURLParameter("version");
         var quiet = getURLParameter("quiet");


### PR DESCRIPTION
There are currently no applicable shortcuts for the Discover page, so the relevant line has been removed.

The impact is that all browser defaults are active.

