### PR TITLE
Find can now be invoked using shortcut in View mode

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -277,6 +277,7 @@ RCloud.UI.find_replace = (function() {
                     ['command', 'f'],
                     ['ctrl', 'f']
                 ],
+                modes: ['writeable', 'readonly'],
                 action: function() { toggle_find_replace(false); }
             }, {
                 category: 'Notebook Management',
@@ -286,6 +287,7 @@ RCloud.UI.find_replace = (function() {
                     ['command', 'option', 'f'],
                     ['ctrl', 'h']
                 ],
+                modes: ['writeable'],
                 action: function() { toggle_find_replace(!shell.notebook.model.read_only()); }
             }]);
         }

--- a/htdocs/view.html
+++ b/htdocs/view.html
@@ -39,6 +39,20 @@
       </div>
     </div>
 
+    <script type="text/template" id="find-in-notebook-snippet">
+      <div id="find-dialog">
+        <form id="find-form">
+          <i class="icon-search"></i>
+          <div class="find">
+            <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
+            <button id="find-last" class="btn"><i class="icon-arrow-left"></i></button>
+            <button id="find-next" class="btn btn-primary"><i class="icon-arrow-right"></i></button>
+          </div>
+        </form>
+        <a id="find-close" href="javascript:void(0)"><i class="icon-remove"></i></a>
+      </div>
+    </script>
+
     <script type="text/javascript"
             src="/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>


### PR DESCRIPTION
The template used by `find_replace.js` was not in `view.html`.

I have added this, and taken out the 'replace' part of the template, since it is not required in 'view'.

Additionally, the 'Replace' shortcut was registered (though it too wasn't doing anything) for 'View', and was showing up, erroneously, on the shortcuts help dialog.