### PR TITLE
Shortcuts are not invoked whilst a dialog is visible

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -23,6 +23,7 @@ RCloud.UI.init = function() {
                 shell.notebook.controller.move_cell(model, next);
             },
             handle: " .cell-status",
+            helper: 'clone',
             scroll: true,
             scrollSensitivity: 40,
             forcePlaceholderSize: true
@@ -198,9 +199,7 @@ RCloud.UI.init = function() {
         ],
         modes: ['writeable', 'readonly'],
         action: function(e) {
-            if(!$('.modal').is(':visible')) {
-                RCloud.UI.shortcut_dialog.show(); 
-            }
+            RCloud.UI.shortcut_dialog.show(); 
         }
     }, {
         category: 'General',
@@ -209,6 +208,7 @@ RCloud.UI.init = function() {
         keys: [
             ['esc']
         ],
+        enable_in_dialogs: true,
         global: true,
         action: function() { $('.modal').modal('hide'); }
     }]);

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -94,7 +94,7 @@ RCloud.UI.shortcut_manager = (function() {
                         shortcut_to_add.create = function() {
                             _.each(shortcut_to_add.key_bindings, function(binding) {
 
-                                var func_to_bind = function(e, keycode) {
+                                var func_to_bind = function(e) {
                                     if(!is_active(shortcut_to_add)) {
                                         return;
                                     } else {

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -22,7 +22,8 @@ RCloud.UI.shortcut_manager = (function() {
 
             var shortcut_to_add = _.defaults(shortcut, {
                 category: 'General',
-                modes: ['writeable', 'readonly']
+                modes: ['writeable', 'readonly'],
+                enable_in_dialogs: false
             });
 
             // if this is not a mac, filter out the 'command' options:
@@ -93,19 +94,26 @@ RCloud.UI.shortcut_manager = (function() {
                         shortcut_to_add.create = function() {
                             _.each(shortcut_to_add.key_bindings, function(binding) {
 
-                                var func_to_bind = function(e) {
+                                var func_to_bind = function(e, keycode) {
                                     if(!is_active(shortcut_to_add)) {
                                         return;
                                     } else {
+
                                         e.preventDefault();
-                                        shortcut.action(e);
+
+                                        // invoke if conditions are met:
+                                        if((shortcut.enable_in_dialogs && $('.modal').is(':visible')) ||
+                                           !$('.modal').is(':visible')) {
+                                            shortcut.action(e);
+                                        }
+
                                     }
                                 };
 
                                 if(shortcut_to_add.global) {
                                     window.Mousetrap.bindGlobal(binding, func_to_bind);
                                 } else {
-                                    window.Mousetrap(document.querySelector('body')).bind(binding, func_to_bind);
+                                   window.Mousetrap().bind(binding, func_to_bind);
                                 }
                             });
                         };


### PR DESCRIPTION
I have added an `enable_in_dialogs` property to shortcuts. By default this is false and means that when a dialog is shown, an action does not occur. This fixes #1910.

I have modified the 'esc' -> close dialog shortcut so that this property value is true. Because we want to be able to close a dialog.