### PR TITLE
Undo/redo issues resolved

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1476,17 +1476,27 @@ var editor = function () {
                 });
         },
         step_history_undo: function() {
+
+            RCloud.UI.shortcut_manager.disable(['history_undo', 'history_redo']);
+
             var previous_version = history_manager.get_previous();
 
             if(!_.isUndefined(previous_version)) {
-                this.load_notebook(current_.notebook, previous_version);
+                this.load_notebook(current_.notebook, previous_version).then(function() {
+                    RCloud.UI.shortcut_manager.enable(['history_undo', 'history_redo']);
+                });
             }
         },
         step_history_redo: function() {
+
+            RCloud.UI.shortcut_manager.disable(['history_undo', 'history_redo']);
+
             var next_version = history_manager.get_next();
 
             if(!_.isUndefined(next_version)) {
-                this.load_notebook(current_.notebook, next_version);
+                this.load_notebook(current_.notebook, next_version).then(function() {
+                    RCloud.UI.shortcut_manager.enable(['history_undo', 'history_redo']);
+                });
             }
         },
         update_recent_notebooks: function(data) {

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -140,7 +140,6 @@ RCloud.UI.init = function() {
             ['command', 'z'],
             ['ctrl', 'z']
         ],
-        modes: ['writeable'],
         action: function() { editor.step_history_undo(); }
     }, {
         category: 'Notebook Management',
@@ -150,7 +149,6 @@ RCloud.UI.init = function() {
             ['ctrl', 'y'],
             ['command', 'shift', 'z']
         ],
-        modes: ['writeable'],
         action: function() { editor.step_history_redo(); }
     }]);
 


### PR DESCRIPTION
This pull request is aimed at fixing #1876 and #1899.

#1899 was a simple fix, removing the `modes` property value of `writeable` from the undo/redo shortcuts, so they use the default of 'writeable' and 'readonly'. 

#1876 required a little more work, and I noticed that the shortcut code's use of the `modes` property was only happening at the point they were added. I modified the code so that the shortcuts are added, and when they are invoked, it checks to see if they should be actioned. 

To fix #1876, I took an approach that when the user steps back (undo) or forwards (redo) in the notebook history using a shortcut, that they should have to wait until that notebook is loaded before stepping again. I tried repeatedly undoing, and from the user's perspective, it's not easy to know exactly what's happening.

To that end, I introduced the `disable` and `enable` functions to the `shortcut_manager`. They both take an array (or single string) for the IDs of the shortcuts that should be disabled or enabled. When the history manager's `step_history_undo` and `step_history_redo` functions are called, the undo/redo shortcuts are disabled. When the notebook has loaded, the shortcuts are enabled.