### PR TITLE
Replace fields hidden for read-only notebooks

### DIFF
--- a/htdocs/js/ui/configure_readonly.js
+++ b/htdocs/js/ui/configure_readonly.js
@@ -28,6 +28,7 @@ RCloud.UI.configure_readonly = function() {
             .prop('checked', false)
             .attr("disabled", true);
         RCloud.UI.scratchpad.set_readonly(true);
+        RCloud.UI.find_replace.hide_replace();
     }
     else {
         RCloud.UI.command_prompt.readonly(false);

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -292,7 +292,9 @@ RCloud.UI.find_replace = (function() {
             }]);
         },
         hide_replace: function() {
-            replace_stuff_.hide();
+            if(replace_stuff_) {
+                replace_stuff_.hide();
+            }
         }
     };
     return result;

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -290,6 +290,9 @@ RCloud.UI.find_replace = (function() {
                 modes: ['writeable'],
                 action: function() { toggle_find_replace(!shell.notebook.model.read_only()); }
             }]);
+        },
+        hide_replace: function() {
+            replace_stuff_.hide();
         }
     };
     return result;


### PR DESCRIPTION
I considered there to be two issues with #1958. The first was that the 'replace' fields could be shown for read-only notebooks using the keyboard shortcut. That was implemented with the fix for #1876 (submitted with PR #1965).

The second issue is that the 'replace' fields are not hidden when (using undo) the notebook changes from writable to read-only. Commit 5fe27bd fixes this with two straightforward modifications, described in the changed files below.
