### PR TITLE
Find/replace bugs suggested fix

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1233,7 +1233,8 @@ var editor = function () {
                     .then(that.load_callback({version: version,
                                               source: source,
                                               selroot: selroot,
-                                              push_history: push_history}));
+                                              push_history: push_history}))
+                    .then(function() { RCloud.UI.find_replace.reset(); });
             })
                 .catch(function(xep) {
                     return shell.improve_load_error(xep, gistname, version).then(function(message) {

--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -26,6 +26,10 @@ Notebook.create_controller = function(model)
         };
     }();
 
+    var refresh_search = _.debounce(function() {
+        update_notebook(refresh_buffers()).then(function() { RCloud.UI.find_replace.reset(); })
+    }, 350);
+
     function append_cell_helper(content, type, id) {
         var cell_model = Notebook.Cell.create_model(content, type);
         var cell_controller = Notebook.Cell.create_controller(cell_model);
@@ -228,6 +232,8 @@ Notebook.create_controller = function(model)
                 result.save();
                 save_timer_ = null;
             }, save_timeout);
+
+        refresh_search();
     }
 
     model.dishers.push({on_dirty: on_dirty});

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -295,6 +295,13 @@ RCloud.UI.find_replace = (function() {
             if(replace_stuff_) {
                 replace_stuff_.hide();
             }
+        },
+        reset: function() {
+            if(find_dialog_) {
+                active_match_ = undefined;
+                build_regex(find_input_.val());
+                highlight_all();
+            }
         }
     };
     return result;

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -297,10 +297,17 @@ RCloud.UI.find_replace = (function() {
             }
         },
         reset: function() {
+
             if(find_dialog_) {
                 active_match_ = undefined;
                 build_regex(find_input_.val());
                 highlight_all();
+            }
+
+        },
+        update_search: function() {
+            if(find_dialog_ && find_dialog_.is(':visible')) {
+                this.reset();
             }
         }
     };


### PR DESCRIPTION
So, I'm not sure that this is ready to merge as it stands, but here's the pull request for you to look at.

I've added some code to the `on_dirty` function of `notebook_controller` to refresh the search results. This uses underscore's `debounce` function, with a `wait` parameter of 350ms, to rate limit the call of `find_replace`'s `reset` function. This redoes the searching.

Before these changes, the highlighting can get really screwed up, and this can occur occasionally because of that 350ms `wait` value.

I feel that the changes for #1960 (1017dde) are less contentious than the other fixes. `load_notebook` now resets the search.

Feedback welcome. Thanks.