### PR TITLE
Panel order change, setting to revert

### DIFF
--- a/htdocs/js/ui/panel_loader.js
+++ b/htdocs/js/ui/panel_loader.js
@@ -1,5 +1,6 @@
 RCloud.UI.panel_loader = (function() {
     var extension_;
+    var panel_data_ = {};
     var panels_ = {};
 
     function collapse_name(name) {
@@ -82,8 +83,7 @@ RCloud.UI.panel_loader = (function() {
                 }
             });
 
-            // built-in panels
-            this.add({
+            panel_data_ = {
                 Notebooks: {
                     side: 'left',
                     name: 'notebook-tree',
@@ -157,7 +157,7 @@ RCloud.UI.panel_loader = (function() {
                     sort: 4000,
                     panel: RCloud.UI.session_pane
                 }
-            });
+            };
         },
         add: function(P) {
             // if we have not been initialized, that means there is no GUI
@@ -174,6 +174,9 @@ RCloud.UI.panel_loader = (function() {
             return $($('#' + id).html())[0];
         },
         load: function() {
+
+            var that = this;
+
             function do_side(panels, side) {
                 function do_panel(p) {
                     add_panel(p);
@@ -193,14 +196,38 @@ RCloud.UI.panel_loader = (function() {
                 add_filler_panel(side);
             }
 
-            do_side(panels_, 'left');
-            do_side(panels_, 'right');
+            // alternative layout?
+            return rcloud.config.get_user_option('panel-layout-by-size').then(function(layoutBySize) { 
+                
+                if(!layoutBySize) {
 
-            // this is dumb but i don't want the collapser to show until load time
-            $('#left-column').append(this.load_snippet('left-pane-collapser-snippet'));
-            $('#right-column').append(this.load_snippet('right-pane-collapser-snippet'));
+                    var update_panel = function update_panel(panel, side, sort) {
+                        panel_data_[panel].side = side;
+                        panel_data_[panel].sort = sort;
+                    };
 
-            return Promise.cast(undefined); // until we are loading opts here
+                    // adjust:
+                    _.each(['Notebooks', 'File Upload', 'Settings', 'Comments'], function(panel, index) {
+                        update_panel(panel, 'left', (index + 1) * 1000);
+                    });
+
+                    _.each(['Assets', 'Search', 'Help', 'Session'], function(panel, index) {
+                        update_panel(panel, 'right', (index + 1) * 1000);
+                    });
+
+                }
+
+                that.add(panel_data_);
+
+                do_side(panels_, 'left');
+                do_side(panels_, 'right');
+
+                // this is dumb but i don't want the collapser to show until load time
+                $('#left-column').append(that.load_snippet('left-pane-collapser-snippet'));
+                $('#right-column').append(that.load_snippet('right-pane-collapser-snippet'));
+
+                return Promise.cast(undefined); // until we are loading opts here
+            });
         }
     };
 })();

--- a/htdocs/js/ui/panel_loader.js
+++ b/htdocs/js/ui/panel_loader.js
@@ -81,6 +81,7 @@ RCloud.UI.panel_loader = (function() {
                     }
                 }
             });
+
             // built-in panels
             this.add({
                 Notebooks: {
@@ -93,14 +94,14 @@ RCloud.UI.panel_loader = (function() {
                     sort: 1000,
                     panel: RCloud.UI.notebooks_frame
                 },
-                Search: {
+                'File Upload': {
                     side: 'left',
-                    name: 'search',
-                    title: 'Search',
-                    icon_class: 'icon-search',
-                    colwidth: 4,
+                    name: 'file-upload',
+                    title: 'File Upload',
+                    icon_class: 'icon-upload-alt',
+                    colwidth: 2,
                     sort: 2000,
-                    panel: RCloud.UI.search
+                    panel: RCloud.UI.upload_frame
                 },
                 Settings: {
                     side: 'left',
@@ -111,15 +112,15 @@ RCloud.UI.panel_loader = (function() {
                     sort: 3000,
                     panel: RCloud.UI.settings_frame
                 },
-                Help: {
+                Comments: {
                     side: 'left',
-                    name: 'help',
-                    title: 'Help',
-                    icon_class: 'icon-question',
-                    colwidth: 5,
+                    name: 'comments',
+                    title: 'Comments',
+                    icon_class: 'icon-comments',
+                    colwidth: 2,
                     sort: 4000,
-                    panel: RCloud.UI.help_frame
-                },
+                    panel: RCloud.UI.comments_frame
+                },                
                 Assets: {
                     side: 'right',
                     name: 'assets',
@@ -129,23 +130,23 @@ RCloud.UI.panel_loader = (function() {
                     sort: 1000,
                     panel: RCloud.UI.scratchpad
                 },
-                'File Upload': {
+                Search: {
                     side: 'right',
-                    name: 'file-upload',
-                    title: 'File Upload',
-                    icon_class: 'icon-upload-alt',
-                    colwidth: 2,
+                    name: 'search',
+                    title: 'Search',
+                    icon_class: 'icon-search',
+                    colwidth: 4,
                     sort: 2000,
-                    panel: RCloud.UI.upload_frame
+                    panel: RCloud.UI.search
                 },
-                Comments: {
+                Help: {
                     side: 'right',
-                    name: 'comments',
-                    title: 'Comments',
-                    icon_class: 'icon-comments',
-                    colwidth: 2,
+                    name: 'help',
+                    title: 'Help',
+                    icon_class: 'icon-question',
+                    colwidth: 5,
                     sort: 3000,
-                    panel: RCloud.UI.comments_frame
+                    panel: RCloud.UI.help_frame
                 },
                 Session: {
                     side: 'right',

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -169,6 +169,12 @@ RCloud.UI.settings_frame = (function() {
                         shell.notebook.controller.show_cell_numbers(val);
                     }
                 }),
+                'panel-layout-by-size': that.checkbox({
+                    sort: 4000,
+                    default_value: true,
+                    needs_reload: true,
+                    label: "Arrange panels by size"
+                }),
                 'addons': that.text_input_vector({
                     sort: 10000,
                     needs_reload: true,


### PR DESCRIPTION
Modified the panels so that by default, they are in a different order (associated by size.)

Added a checkbox for the 'Arrange Panels by Size' setting, defaulting to 'true'. Changing requires a reload.

On load, the setting is read and panels are rearranged if necessary.

This fixes #1802.