### PR TITLE
Enable/disable extensions text supports comma, slash and space separators

### DIFF
--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -132,7 +132,7 @@ RCloud.UI.settings_frame = (function() {
         text_input_vector: function(opts) {
             opts = _.extend({
                 parse: function(val) {
-                    return val.trim().split(/, */).filter(function(x) { return !!x; });
+                    return val.trim().split(/[\s,/]+/).filter(function(x) { return !!x; });
                 },
                 format: function(val) {
                     // might be devectorized by rserve.js

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -132,7 +132,7 @@ RCloud.UI.settings_frame = (function() {
         text_input_vector: function(opts) {
             opts = _.extend({
                 parse: function(val) {
-                    return val.trim().split(/[\s,/]+/).filter(function(x) { return !!x; });
+                    return val.trim().split(/[\s,/]+/);
                 },
                 format: function(val) {
                     // might be devectorized by rserve.js


### PR DESCRIPTION
Regex mod; `filter` has been removed because I don't think it's required.