### PR TITLE
Cell/shortcut enhancements

### DIFF
--- a/htdocs/js/notebook/cell_model.js
+++ b/htdocs/js/notebook/cell_model.js
@@ -34,6 +34,7 @@ Notebook.Cell.create_model = function(content, language)
         set_focus: function() {
             this.notify_views(function(view) {
                 view.edit_source(true);
+                view.scroll_into_view(true);
             });
         },
         deselect_cell: function() {

--- a/htdocs/js/notebook/cell_model.js
+++ b/htdocs/js/notebook/cell_model.js
@@ -31,6 +31,11 @@ Notebook.Cell.create_model = function(content, language)
                 version: this.parent_model.controller.current_gist().history[0].version
             };
         },
+        set_focus: function() {
+            this.notify_views(function(view) {
+                view.edit_source(true);
+            });
+        },
         deselect_cell: function() {
             is_selected_ = false;
 

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -355,9 +355,20 @@ function create_cell_html_view(language, cell_model) {
                 mac: 'Alt-Return',
                 sender: 'editor'
             },
-            exec: function(ace_widget_, args, request) {
+            exec: function() {
                 result.execute_cell();
             }
+        }, {
+            name: 'executeCellsFromHere',
+            bindKey: {
+                win: 'Shift-Alt-Return',
+                mac: 'Shift-Alt-Return',
+                sender: 'editor'
+            },
+            exec: function() {
+                shell.run_notebook_from(cell_model.id());
+            }
+
         }]);
         ace_widget_.commands.removeCommands(['find', 'replace']);
         change_content_ = ui_utils.ignore_programmatic_changes(ace_widget_, function() {

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -376,7 +376,11 @@ function create_cell_html_view(language, cell_model) {
                 sender: 'editor'
             },
             exec: function() {
-                console.log('beginning of previous cell');
+                var prior_cell = cell_model.parent_model.prior_cell(cell_model);
+
+                if(prior_cell) {
+                    prior_cell.set_focus();
+                }
             }
         }, {
             name: 'navigateTopNextCell',
@@ -386,7 +390,11 @@ function create_cell_html_view(language, cell_model) {
                 sender: 'editor'
             },
             exec: function() {
-                console.log('beginning of next cell');
+                var subsequent_cell = cell_model.parent_model.subsequent_cell(cell_model);
+
+                if(subsequent_cell) {
+                    subsequent_cell.set_focus();
+                }
             }
         }]);
         ace_widget_.commands.removeCommands(['find', 'replace']);

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -422,7 +422,28 @@ function create_cell_html_view(language, cell_model) {
                         controller.edit_source(true);
                     });
             }
-        }]);
+        }/*, {
+            name: 'traverseCellPrevious', 
+            bindKey: {
+                win: 'Left',
+                mac: 'Left',
+                sender: 'editor',
+            },
+            exec: function() {
+                console.log('traverse previous');
+            }
+        }, {
+            name: 'traverseCellNext', 
+            bindKey: {
+                win: 'Right',
+                mac: 'Right',
+                sender: 'editor',
+            },
+            exec: function() {
+                console.log('traverse next');
+            }
+        }*/]);
+
         ace_widget_.commands.removeCommands(['find', 'replace']);
         change_content_ = ui_utils.ignore_programmatic_changes(ace_widget_, function() {
             cell_changed();

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -368,7 +368,26 @@ function create_cell_html_view(language, cell_model) {
             exec: function() {
                 shell.run_notebook_from(cell_model.id());
             }
-
+        }, {
+            name: 'navigateTopPreviousCell',
+            bindKey: {
+                win: 'Alt-Up',
+                mac: 'Alt-Up',
+                sender: 'editor'
+            },
+            exec: function() {
+                console.log('beginning of previous cell');
+            }
+        }, {
+            name: 'navigateTopNextCell',
+            bindKey: {
+                win: 'Alt-Down',
+                mac: 'Alt-Down',
+                sender: 'editor'
+            },
+            exec: function() {
+                console.log('beginning of next cell');
+            }
         }]);
         ace_widget_.commands.removeCommands(['find', 'replace']);
         change_content_ = ui_utils.ignore_programmatic_changes(ace_widget_, function() {

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -773,6 +773,35 @@ function create_cell_html_view(language, cell_model) {
             edit_mode_ = edit_mode;
             this.change_highlights(highlights_); // restore highlights
         },
+        scroll_into_view: function() {
+            var renderer = ace_widget_.renderer;
+            var pos = renderer.$cursorLayer.$pixelPos;
+            var config = renderer.layerConfig;
+            var top = pos.top - config.offset;
+
+            // shouldScoll  = true  = ^
+            // shouldScroll = false = v
+            if (pos.top >= 0 && top + rect.top < $('#rcloud-cellarea').offset().top) {
+                shouldScroll = true;
+            } else if (pos.top < config.height &&
+                pos.top + rect.top + config.lineHeight > window.innerHeight) {
+                shouldScroll = false;
+            } else {
+                shouldScroll = null;
+            }
+
+            if (shouldScroll != null) {
+                var ace_div = $(renderer.$cursorLayer.element).closest('.outer-ace-div');
+                var scroll_top = (ace_div.offset().top + $('#rcloud-cellarea').scrollTop()) - $('#rcloud-cellarea').offset().top;
+                scroll_top += pos.top;
+
+                if(shouldScroll) {
+                    $('#rcloud-cellarea').scrollTop(scroll_top);
+                } else {
+                    $('#rcloud-cellarea').scrollTop(scroll_top - $('#rcloud-cellarea').height() + config.lineHeight);
+                }
+            }
+        },
         toggle_source: function() {
             this.hide_source($(source_div_).is(":visible"));
         },

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -396,6 +396,32 @@ function create_cell_html_view(language, cell_model) {
                     subsequent_cell.set_focus();
                 }
             }
+        }, {
+            name: 'insertCellPrevious', 
+            bindKey: {
+                win: 'Ctrl-[',
+                mac: 'Ctrl-[',
+                sender: 'editor',
+            },
+            exec: function() {
+                shell.insert_cell_before("", cell_model.language(), cell_model.id())
+                    .spread(function(_, controller) {
+                        controller.edit_source(true);
+                    });
+            }
+        }, {
+            name: 'insertCellNext', 
+            bindKey: {
+                win: 'Ctrl-]',
+                mac: 'Ctrl-]',
+                sender: 'editor',
+            },
+            exec: function() {
+                shell.insert_cell_after("", cell_model.language(), cell_model.id())
+                    .spread(function(_, controller) {
+                        controller.edit_source(true);
+                    });
+            }
         }]);
         ace_widget_.commands.removeCommands(['find', 'replace']);
         change_content_ = ui_utils.ignore_programmatic_changes(ace_widget_, function() {

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -775,6 +775,7 @@ function create_cell_html_view(language, cell_model) {
         },
         scroll_into_view: function() {
             var renderer = ace_widget_.renderer;
+            var rect = renderer.container.getBoundingClientRect();
             var pos = renderer.$cursorLayer.$pixelPos;
             var config = renderer.layerConfig;
             var top = pos.top - config.offset;

--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -525,6 +525,18 @@ Notebook.create_controller = function(model)
                 });
             });
         },
+        run_from: function(cell_id) {
+            var that = this,
+                process = false;
+            return this.save().then(function() {
+                _.each(model.cells, function(cell_model) {
+                    if(process || cell_model.id() === cell_id) {
+                        process = true;
+                        cell_model.controller.enqueue_execution_snapshot();
+                    }
+                });
+            });
+        },
         show_cell_numbers: function(whether) {
             _.each(model.views, function(view) {
                 view.set_show_cell_numbers(whether);

--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -297,6 +297,18 @@ Notebook.create_controller = function(model)
             return update_notebook(changes)
                 .then(default_callback());
         },
+        navigate_beginning_previous: function() {
+
+        },
+        navigate_beginning_next: function() {
+
+        },
+        navigate_next: function() {
+
+        },
+        navigate_previous: function() {
+
+        },
         can_crop_cells: function() {
             return model.can_crop_cells();
         },

--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -297,18 +297,6 @@ Notebook.create_controller = function(model)
             return update_notebook(changes)
                 .then(default_callback());
         },
-        navigate_beginning_previous: function() {
-
-        },
-        navigate_beginning_next: function() {
-
-        },
-        navigate_next: function() {
-
-        },
-        navigate_previous: function() {
-
-        },
         can_crop_cells: function() {
             return model.can_crop_cells();
         },

--- a/htdocs/js/notebook/notebook_model.js
+++ b/htdocs/js/notebook/notebook_model.js
@@ -259,6 +259,13 @@ Notebook.create_model = function()
             else
                 return null;
         },
+        subsequent_cell: function(cell_model) {
+            var index = this.cells.indexOf(cell_model);
+            if(index < this.cells.length - 1)
+                return this.cells[index + 1];
+            else
+                return null;
+        },
         change_cell_language: function(cell_model, language) {
             // for this one case we have to use filenames instead of ids
             var pre_name = cell_model.filename();

--- a/htdocs/js/ui/cell_commands.js
+++ b/htdocs/js/ui/cell_commands.js
@@ -44,7 +44,7 @@ RCloud.UI.cell_commands = (function() {
                 // when they are set to container = body
                 $(".tooltip").remove();
                 if (!$(e.currentTarget).hasClass("button-disabled")) {
-                    action(control);
+                    action(control, e);
                 }
             });
             return {
@@ -193,7 +193,7 @@ RCloud.UI.cell_commands = (function() {
                     area: 'cell',
                     sort: 2000,
                     create: function(cell_model, cell_view) {
-                        return that.create_button("icon-play", "run", function() {
+                        return that.create_button("icon-play", "run", function(control, e) {
                             cell_view.execute_cell();
                         });
                     }

--- a/htdocs/js/ui/cell_commands.js
+++ b/htdocs/js/ui/cell_commands.js
@@ -194,7 +194,11 @@ RCloud.UI.cell_commands = (function() {
                     sort: 2000,
                     create: function(cell_model, cell_view) {
                         return that.create_button("icon-play", "run", function(control, e) {
-                            cell_view.execute_cell();
+                            if(e.shiftKey) {
+                                shell.run_notebook_from(cell_model.id());
+                            } else {
+                                cell_view.execute_cell();    
+                            }
                         });
                     }
                 },

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -185,6 +185,24 @@ RCloud.UI.init = function() {
         ],
         modes: ['writeable'],
         action: function() { shell.notebook.controller.crop_cells(); }
+    }, {
+        category: 'Cell Management', 
+        id: 'arrow_next_cell', 
+        description: 'Enter next cell (from end of current)',
+        keys: [
+            ['right']
+        ],
+        modes: ['writeable'],
+        action: function() { }
+    }, {
+        category: 'Cell Management', 
+        id: 'arrow_next_cell', 
+        description: 'Enter previous cell (from start of current)',
+        keys: [
+            ['left']
+        ],
+        modes: ['writeable'],
+        action: function() { }
     }]);
 
     // general:

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -203,6 +203,24 @@ RCloud.UI.init = function() {
         ],
         modes: ['writeable'],
         action: function() { }
+    }, {
+        category: 'Cell Management', 
+        id: 'beginning_next_cell', 
+        description: 'Go to beginning of next cell',
+        keys: [
+            ['alt', 'up']
+        ],
+        modes: ['writeable'],
+        action: function() { }
+    }, {
+        category: 'Cell Management', 
+        id: 'beginning_previous_cell', 
+        description: 'Go to beginning of previous cell',
+        keys: [
+            ['alt', 'down']
+        ],
+        modes: ['writeable'],
+        action: function() { }
     }]);
 
     // general:

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -196,7 +196,7 @@ RCloud.UI.init = function() {
         action: function() { }
     }, {
         category: 'Cell Management', 
-        id: 'arrow_next_cell', 
+        id: 'arrow_previous_cell', 
         description: 'Enter previous cell (from start of current)',
         keys: [
             ['left']

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -193,7 +193,7 @@ RCloud.UI.init = function() {
             ['right']
         ],
         modes: ['writeable'],
-        action: function() { }
+        action: function() { shell.notebook.controller.navigate_next(); }
     }, {
         category: 'Cell Management', 
         id: 'arrow_previous_cell', 
@@ -202,22 +202,40 @@ RCloud.UI.init = function() {
             ['left']
         ],
         modes: ['writeable'],
-        action: function() { }
+        action: function() { shell.notebook.controller.navigate_previous(); }
     }, {
         category: 'Cell Management', 
         id: 'beginning_next_cell', 
         description: 'Go to beginning of next cell',
         keys: [
-            ['alt', 'up']
+            ['alt', 'down']
         ],
         modes: ['writeable'],
-        action: function() { }
+        action: function() { shell.notebook.controller.navigate_beginning_next(); }
     }, {
         category: 'Cell Management', 
         id: 'beginning_previous_cell', 
         description: 'Go to beginning of previous cell',
         keys: [
-            ['alt', 'down']
+            ['alt', 'up']
+        ],
+        modes: ['writeable'],
+        action: function() { shell.notebook.controller.navigate_beginning_previous(); }
+    }, {
+        category: 'Cell Management', 
+        id: 'insert_cell_after', 
+        description: 'Insert cell after current',
+        keys: [
+            ['ctrl', '/']
+        ],
+        modes: ['writeable'],
+        action: function() { }
+    }, {
+        category: 'Cell Management', 
+        id: 'insert_cell_before', 
+        description: 'Insert cell before current',
+        keys: [
+            ['ctrl', '\\']
         ],
         modes: ['writeable'],
         action: function() { }

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -192,8 +192,7 @@ RCloud.UI.init = function() {
         keys: [
             ['right']
         ],
-        modes: ['writeable'],
-        action: function() { shell.notebook.controller.navigate_next(); }
+        modes: ['writeable']
     }, {
         category: 'Cell Management', 
         id: 'arrow_previous_cell', 
@@ -201,8 +200,7 @@ RCloud.UI.init = function() {
         keys: [
             ['left']
         ],
-        modes: ['writeable'],
-        action: function() { shell.notebook.controller.navigate_previous(); }
+        modes: ['writeable']
     }, {
         category: 'Cell Management', 
         id: 'beginning_next_cell', 
@@ -210,8 +208,7 @@ RCloud.UI.init = function() {
         keys: [
             ['alt', 'down']
         ],
-        modes: ['writeable'],
-        action: function() { shell.notebook.controller.navigate_beginning_next(); }
+        modes: ['writeable']
     }, {
         category: 'Cell Management', 
         id: 'beginning_previous_cell', 
@@ -219,8 +216,7 @@ RCloud.UI.init = function() {
         keys: [
             ['alt', 'up']
         ],
-        modes: ['writeable'],
-        action: function() { shell.notebook.controller.navigate_beginning_previous(); }
+        modes: ['writeable']
     }, {
         category: 'Cell Management', 
         id: 'insert_cell_after', 

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -239,6 +239,14 @@ RCloud.UI.init = function() {
         ],
         modes: ['writeable'],
         action: function() { }
+    }, {
+        category: 'Cell Management', 
+        id: 'cell_run_from_here', 
+        description: 'Run from here (within a cell)',
+        keys: [
+            ['shift', 'alt', 'enter']
+        ],
+        modes: ['writeable']
     }]);
 
     // general:

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -203,6 +203,14 @@ RCloud.UI.init = function() {
         modes: ['writeable']
     }, {
         category: 'Cell Management', 
+        id: 'beginning_previous_cell', 
+        description: 'Go to beginning of previous cell',
+        keys: [
+            ['alt', 'up']
+        ],
+        modes: ['writeable']
+    }, {        
+        category: 'Cell Management', 
         id: 'beginning_next_cell', 
         description: 'Go to beginning of next cell',
         keys: [
@@ -211,27 +219,19 @@ RCloud.UI.init = function() {
         modes: ['writeable']
     }, {
         category: 'Cell Management', 
-        id: 'beginning_previous_cell', 
-        description: 'Go to beginning of previous cell',
+        id: 'insert_cell_before', 
+        description: 'Insert cell before current',
         keys: [
-            ['alt', 'up']
+            ['ctrl', '[']
         ],
-        modes: ['writeable']
-    }, {
+        modes: ['writeable'],
+        action: function() { }
+    }, {        
         category: 'Cell Management', 
         id: 'insert_cell_after', 
         description: 'Insert cell after current',
         keys: [
-            ['ctrl', '/']
-        ],
-        modes: ['writeable'],
-        action: function() { }
-    }, {
-        category: 'Cell Management', 
-        id: 'insert_cell_before', 
-        description: 'Insert cell before current',
-        keys: [
-            ['ctrl', '\\']
+            ['ctrl', ']']
         ],
         modes: ['writeable'],
         action: function() { }

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -185,7 +185,7 @@ RCloud.UI.init = function() {
         ],
         modes: ['writeable'],
         action: function() { shell.notebook.controller.crop_cells(); }
-    }, {
+    }/*, {
         category: 'Cell Management', 
         id: 'arrow_next_cell', 
         description: 'Enter next cell (from end of current)',
@@ -201,7 +201,7 @@ RCloud.UI.init = function() {
             ['left']
         ],
         modes: ['writeable']
-    }, {
+    }*/, {
         category: 'Cell Management', 
         id: 'beginning_previous_cell', 
         description: 'Go to beginning of previous cell',

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -207,10 +207,13 @@ RCloud.UI.shortcut_manager = (function() {
         },
         get_registered_shortcuts_by_category: function(sort_items) {
 
+            console.log(extension_.sections.all.entries);
+
             var rank = _.map(sort_items, (function(item, index) { return { key: item, value: index + 1 }}));
             rank = _.object(_.pluck(rank, 'key'), _.pluck(rank, 'value'));
 
-            var available_shortcuts = _.filter(extension_.sections.all.entries, function(s) { return is_active(s); });
+            var available_shortcuts = _.filter(_.sortBy(extension_.sections.all.entries, function(shortcut) { return shortcut.category + shortcut.description; }), 
+                function(s) { return is_active(s); });
 
             return _.sortBy(_.map(_.chain(available_shortcuts).groupBy('category').value(), function(item, key) {
                 return { category: key, shortcuts: item };

--- a/htdocs/shell_tab.js
+++ b/htdocs/shell_tab.js
@@ -119,7 +119,12 @@ var shell = (function() {
         insert_cell_before: function(content, language, index) {
             check_cell_language(language);
             return notebook_controller_.insert_cell(content, language, index);
-        }, join_prior_cell: function(cell_model) {
+        }, 
+        insert_cell_after: function(content, language, index) {
+            check_cell_language(language);
+            return notebook_controller_.insert_cell(content, language, index + 1);
+        },
+        join_prior_cell: function(cell_model) {
             return notebook_controller_.join_prior_cell(cell_model);
         }, split_cell: function(cell_model, point1, point2) {
             return notebook_controller_.split_cell(cell_model, point1, point2);

--- a/htdocs/shell_tab.js
+++ b/htdocs/shell_tab.js
@@ -309,6 +309,12 @@ var shell = (function() {
             }).then(function() {
                 RCloud.UI.command_prompt.focus();
             });
+        }, run_notebook_from: function(cell_id) {
+            RCloud.UI.with_progress(function() {
+                return result.notebook.controller.run_from(cell_id);
+            }).then(function() {
+                RCloud.UI.command_prompt.focus();
+            });
         }
     };
 


### PR DESCRIPTION
This PR addresses 2 enhancements: #1439 and #1949. It also fixes the shortcut dialog ordering inconsistency #1987.

### #1439 ###

I haven't yet been able to implement an arrow left/right into previous/next cell shortcut. If you add an action to an existing shortcut, that existing shortcut is overridden. 

Alt-up, alt-down don't actually go to the start of the previous/next cell. I reused some existing code, and the cursor will reuse an existing cursor point, if it exists. If not, it will position the cursor at the top of the cell. I realise this is different to the enhancement's requirement, but I think it's an interesting variation that might be a better solution. 

I have implemented ctrl-[ and ctrl-] for insert cell before/after current.

These shortcuts are implemented using ACE, but have been documented using the shortcut manager, so that they appear in the shortcuts dialog.

### #1949 ###

Implemented as a shortcut and shift-click play icon on individual cell.

---

### #1987 ###

Quick fix for this one to ensure consistent ordering between Firefox/Chrome.







