### PR TITLE
Clearer error reporting in mini and shiny.

### DIFF
--- a/htdocs/js/ui/session_pane.js
+++ b/htdocs/js/ui/session_pane.js
@@ -46,8 +46,8 @@ RCloud.UI.session_pane = {
     append_text: function(msg) {
         // FIXME: dropped here from session.js, could be integrated better
         if(!$('#session-info').length) {
-            console.log(['session log; ', msg].join(''));
-             return; // workaround for view mode
+            console.log('session log; ', msg);
+            return; // workaround for view mode
         }
         // one hacky way is to maintain a <pre> that we fill as we go
         // note that R will happily spit out incomplete lines so it's
@@ -71,12 +71,14 @@ RCloud.UI.session_pane = {
             throw new Error("post_error expects a string or a jquery div");
         msg.addClass(errclass);
         dest = dest || this.error_dest_;
-        if(dest) { // if initialized, we can use the UI
+        if(dest && dest.length) { // if initialized, we can use the UI
             dest.append(msg);
             this.show_error_area();
             ui_utils.on_next_tick(function() {
                 ui_utils.scroll_to_after($("#session-info"));
             });
+        } else {
+            RCloud.UI.fatal_dialog(msg.text(), "Error", ui_utils.relogin_uri());
         }
         if(!logged)
             console.log("pre-init post_error: " + msg.text());

--- a/htdocs/mini.js
+++ b/htdocs/mini.js
@@ -12,6 +12,22 @@ function main() {
         return res;
     }
 
+    // loosely based on https://codepen.io/gapcode/pen/vEJNZN
+    function isIE() {
+        var ua = window.navigator.userAgent;
+
+        return(ua.indexOf('MSIE ') > 0 ||
+            ua.indexOf('Trident/') > 0 || 
+            ua.indexOf('Edge/') > 0);
+    }
+
+    RCloud.UI.session_pane.init();
+
+    if(isIE()) {
+        RCloud.UI.fatal_dialog("Sorry, Internet Explorer is not supported by RCloud.", "Close");
+        return;
+    }
+
     rclient = RClient.create({
         debug: false,
         mode: "client", // "IDE" = edit (separated), "call" = API (one process), "client" = JS (currently one process but may change)
@@ -19,11 +35,13 @@ function main() {
         on_connect: function(ocaps) {
             rcloud = RCloud.create(ocaps.rcloud);
             var promise;
+
             if (rcloud.authenticated) {
                 promise = rcloud.session_init(rcloud.username(), rcloud.github_token());
             } else {
                 promise = rcloud.anonymous_session_init();
             }
+
             promise = promise.then(function(hello) {
                 rclient.post_response(hello);
             });


### PR DESCRIPTION
- Added `RCloud.UI.session_pane.init();` to `mini.js`.
- `session_pane`'s `init` method assumed that there was a `#session_info` or `#output`. In mini/shiny, there was neither, but the code that later used this assumed there was a `#output` div. I have added a `.length` guard condition. If that is 0, then we have neither, so a fatal dialog is shown.
- `is_IE` function added which sniffs for IE. If IE is detected, a fatal dialog is shown immediately and execution returns. Unsure if this is the best/intended message for IE users. Perhaps the suggestion of using Firefox, Chrome (and others?) would be more useful.