### PR TITLE
Dialogs can be closed with 'esc'. Again.

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -192,7 +192,6 @@ RCloud.UI.init = function() {
         id: 'blur_cell',
         description: 'Blur Cell',
         keys: [
-            ['esc'],
             ['esc']
         ],
         modes: ['writeable']

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -87,15 +87,6 @@ RCloud.UI.shortcut_manager = (function() {
                     shortcut_to_add.key_bindings.push(keys.join('+'));
                 }
 
-                // with existing shortcuts:
-                for(var loop = 0; loop < existing_shortcuts.length; loop++) {
-                    if(_.intersection(existing_shortcuts[loop].key_bindings, shortcut_to_add.key_bindings).length > 0) {
-                        console.warn('Keyboard shortcut "' + shortcut_to_add.description + '" cannot be registered because its keycode clashes with an existing shortcut.');
-                        can_add = false;
-                        break;
-                    }
-                }
-
                 if(can_add) {
 
                     // update any 'command' entries to the '⌘' key:


### PR DESCRIPTION
This fixes #1999, which was caused by the blur cell/close dialog shortcuts using the same shortcut key.

In reality, they do not clash because they operate on different elements.