### PR TITLE
Selected word should populate the find replace 'find' field; tab order on Find/Replace 'dialog'

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -77,8 +77,8 @@
         <button id="replace" class="btn">Replace</button>
         <button id="replace-all" class="btn">Replace All</button>
       </div>
+      <a id="find-close" href="javascript:void(0)"><i class="icon-remove"></i></a>
     </form>
-    <a id="find-close" href="javascript:void(0)"><i class="icon-remove"></i></a>
   </div>
 </script>
 

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -912,6 +912,9 @@ function create_cell_html_view(language, cell_model) {
         get_content: function() { // for debug
             return cell_model.content();
         },
+        get_selection: function() {
+            return this.ace_widget().getSession().doc.getTextRange(this.ace_widget().selection.getRange());
+        },
         reformat: function() {
             if(edit_mode_) {
                 // resize once to get right height, then set height,

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -91,8 +91,8 @@ RCloud.UI.find_replace = (function() {
                 return false;
             });
 
-            find_cycle_ = ['find-input', 'find-next', 'find-last'];
-            replace_cycle_ = ['find-input', 'replace-input', 'find-next', 'find-last', 'replace-all'];
+            find_cycle_ = ['find-input', 'find-last', 'find-next'];
+            replace_cycle_ = ['find-input', 'find-last', 'find-next', 'replace-input', 'replace', 'replace-all'];
 
             function click_find_next(e) {
                 if(e.keyCode===$.ui.keyCode.ENTER) {

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -139,6 +139,13 @@ RCloud.UI.find_replace = (function() {
         }
 
         find_dialog_.show();
+
+        var active_cell_selection = get_active_cell_selection();
+
+        if(active_cell_selection) {
+            find_input_.val(active_cell_selection);
+        }
+
         find_input_.focus();
         if(replace)
             replace_stuff_.show();
@@ -169,6 +176,19 @@ RCloud.UI.find_replace = (function() {
         shell.notebook.model.cells[match.index].notify_views(function(view) {
             view.change_highlights(matches);
         });
+    }
+    function get_active_cell_selection() {
+        var selection;
+
+        var focussed_cell = _.find(shell.notebook.model.cells, function(cell) {
+            return !_.isUndefined(cell.views[0].ace_widget()) && cell.views[0].ace_widget().textInput.isFocused();
+        });
+        
+        if(focussed_cell) {
+            selection = focussed_cell.views[0].get_selection();
+        }
+
+        return selection;
     }
     function active_transition(transition) {
         if(active_match_ !== undefined) {

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -94,6 +94,9 @@ RCloud.UI.find_replace = (function() {
             find_cycle_ = ['find-input', 'find-last', 'find-next'];
             replace_cycle_ = ['find-input', 'find-last', 'find-next', 'replace-input', 'replace', 'replace-all'];
 
+            find_cycle_.push('find-close');
+            replace_cycle_.push('find-close');
+
             function click_find_next(e) {
                 if(e.keyCode===$.ui.keyCode.ENTER) {
                     e.preventDefault();

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -147,6 +147,28 @@ RCloud.UI.find_replace = (function() {
 
         if(active_cell_selection) {
             find_input_.val(active_cell_selection);
+        } else {
+            // any doc-level selection?
+            var sel = window.getSelection(), text;
+
+            var offscreen = $('<pre class="offscreen"></pre>');
+            $('body').append(offscreen);
+            for(var i=0; i < sel.rangeCount; ++i) {
+                var range = sel.getRangeAt(i);
+                offscreen.append(range.cloneContents());
+            }
+            offscreen.find('.nonselectable').remove();
+            sel.selectAllChildren(offscreen[0]);
+
+            text = $(offscreen).text();
+
+            window.setTimeout(function() {
+                offscreen.remove();
+            }, 1000);
+
+            if(text) {
+                find_input_.val(text);
+            }
         }
 
         find_input_.focus();

--- a/htdocs/view.html
+++ b/htdocs/view.html
@@ -48,8 +48,8 @@
             <button id="find-last" class="btn"><i class="icon-arrow-left"></i></button>
             <button id="find-next" class="btn btn-primary"><i class="icon-arrow-right"></i></button>
           </div>
+          <a id="find-close" href="javascript:void(0)"><i class="icon-remove"></i></a>          
         </form>
-        <a id="find-close" href="javascript:void(0)"><i class="icon-remove"></i></a>
       </div>
     </script>
 


### PR DESCRIPTION
An implementation for #1846.

Fixes for #1984 and #1986, both of which are related.

I also include a commit ba563b8, which includes the find/replace close dialog's close button. Seems sensible to me, but easy to leave out if it's not wanted.