### PR TITLE
rcloud.get.notebook.forks

### DIFF
--- a/packages/gist/NAMESPACE
+++ b/packages/gist/NAMESPACE
@@ -1,2 +1,2 @@
-export(auth.url, create.gist, create.gist.comment, current.gist.context, delete.gist.comment, fork.gist, get.gist,
+export(auth.url, create.gist, create.gist.comment, current.gist.context, delete.gist.comment, fork.gist, get.gist.forks, get.gist,
        get.gist.comments, modify.gist, modify.gist.comment, set.gist.context, access.token, context.info, get.user, is.read.only, is.read.only.default)

--- a/packages/gist/R/gists.R
+++ b/packages/gist/R/gists.R
@@ -4,6 +4,9 @@ get.gist  <- function (id, version = NULL, ctx = current.gist.context())
 fork.gist  <- function (id, ctx = current.gist.context())
   UseMethod("fork.gist", ctx)
 
+get.gist.forks  <- function (id, ctx = current.gist.context())
+  UseMethod("get.gist.forks", ctx)
+
 modify.gist  <- function (id, content, ctx = current.gist.context())
   UseMethod("modify.gist", ctx)
 

--- a/packages/githubgist/DESCRIPTION
+++ b/packages/githubgist/DESCRIPTION
@@ -4,5 +4,5 @@ Version: 1.0-3
 Author: Simon Urbanek <urbanek@research.att.com>
 Maintainer: Simon Urbanek <urbanek@research.att.com>
 Description: Gist interface to GitHub
-Imports: gist, github (>= 0.9.7), httr
+Imports: gist, github (>= 0.9.8), httr
 License: MIT

--- a/packages/githubgist/R/do.R
+++ b/packages/githubgist/R/do.R
@@ -47,6 +47,8 @@ get.gist.githubcontext <- function(...) .fix.truncated(github::get.gist(...))
 
 fork.gist.githubcontext <- function(...) .fix.truncated(github::fork.gist(...))
 
+get.gist.forks.githubcontext <- function(...) github::get.gist.forks(...)
+
 modify.gist.githubcontext <- function(...) .fix.truncated(github::modify.gist(...))
 
 create.gist.githubcontext <- function(...) .fix.truncated(github::create.gist(...))

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -416,6 +416,9 @@ rcloud.fork.notebook <- function(id, source = NULL) {
     new.nb
 }
 
+rcloud.get.notebook.forks <- function(id)
+  get.gist.forks(id, ctx = .rcloud.get.gist.context())
+
 rcloud.get.users <- function() ## NOTE: this is a bit of a hack, because it abuses the fact that users are first in usr.key...
   ## also note that we are looking deep in the config space - this shold be really much easier ...
   gsub("/.*","",rcs.list(usr.key(user="*", notebook="system", "config", "current", "notebook")))


### PR DESCRIPTION
Hi @s-u, could you review this? I have never touched the gist codes. I think I'm following the pattern but I may have missed something.

Of course I did not implement this for git gists... I did have to add it to rgithub, thus the version bump and https://github.com/cscheid/rgithub/pull/65

We need this to implement the "most popular notebooks" feature.