### PR TITLE
Shortcut SNAFU has gone

### DIFF
--- a/htdocs/js/ui/ace_shortcuts.js
+++ b/htdocs/js/ui/ace_shortcuts.js
@@ -699,7 +699,7 @@ RCloud.UI.ace_shortcuts = (function() {
                 description: 'Redo',
                 keys: { 
                     mac: [
-                        ['command', 'shift', 'z']
+                        ['command', 'shift', 'z'],
                         ['command', 'y']
                     ],
                     win: [

--- a/htdocs/js/ui/shortcut_dialog.js
+++ b/htdocs/js/ui/shortcut_dialog.js
@@ -42,7 +42,6 @@ RCloud.UI.shortcut_dialog = (function() {
                     var keys_markup = [];
 
                     _.each(shortcut.bind_keys, function(keys) {
-                        keys = keys || ['SNAFU'];
                         keys_markup.push('<kbd>' + keys.join(' ') + '</kbd>');
                     });
 


### PR DESCRIPTION
A missing comma! Mac-specific issue. Fixed. SNAFU removed.

![image](https://cloud.githubusercontent.com/assets/2493614/15820661/d3dfd8c8-2be2-11e6-97bf-c616c9f1dd35.png)
