### PR TITLE
'Run all' and 'Revert notebook' now available (once again) in view mode

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -174,10 +174,14 @@ RCloud.UI.init = function() {
         category: 'Notebook Management',
         id: 'history_revert',
         description: 'Reverts a notebook',
-        keys: [
-            ['ctrl', 'e'],
-            ['command', 'e']
-        ],
+        keys: {
+            mac: [
+                ['command', 'e']
+            ],
+            win: [
+                ['ctrl', 'e']
+            ]
+        },
         action: function() { 
             if(shell.notebook.controller.is_mine() && !shell.is_view_mode()) {
                 editor.revert_notebook(shell.notebook.controller.is_mine(), shell.gistname(), shell.version());
@@ -186,10 +190,14 @@ RCloud.UI.init = function() {
     }, {
         id: 'notebook_run_all',
         description: 'Run all',
-        keys: [
-            ['command', 'u'],
-            ['ctrl', 'u']
-        ],
+        keys: {
+            mac: [
+                ['command', 'u']
+            ],     
+            win: [
+                ['ctrl', 'u']
+            ]
+        },
         action: function() { RCloud.UI.run_button.run(); }
     }]);
 

--- a/htdocs/js/ui/shortcut_dialog.js
+++ b/htdocs/js/ui/shortcut_dialog.js
@@ -39,6 +39,10 @@ RCloud.UI.shortcut_dialog = (function() {
 
                 _.each(group.shortcuts, function(shortcut) {
 
+                    // if(!shortcut.keys.hasOwnProperty('win') && !shortcut.keys.hasOwnProperty('mac') && !shortcut.keys.hasOwnProperty('win_mac')) {
+                    //     console.error('invalid shortcut: ', shortcut);
+                    // }
+
                     var keys_markup = [];
 
                     _.each(shortcut.bind_keys, function(keys) {


### PR DESCRIPTION
Format of shortcut `keys` was incorrect, so it wasn't being picked up correctly. Changed this, and they now appear.

Having looked through the list, I don't *think* that there should be any more, since they relate to the ACE editor and associated shortcuts based on an editable notebook.

This fixes #2021.