### PR TITLE
Prompt selection used for find/replace prepopulation and shortcut multiple invocation fix

### DIFF
--- a/htdocs/js/ui/command_prompt.js
+++ b/htdocs/js/ui/command_prompt.js
@@ -4,7 +4,9 @@ RCloud.UI.command_prompt = (function() {
         history_ = null,
         entry_ = null,
         language_ = null,
-        command_bar_ = null;
+        command_bar_ = null,
+        ace_widget_,
+        ace_session_;
 
     function setup_command_entry() {
         var prompt_div = $("#command-prompt");
@@ -20,9 +22,11 @@ RCloud.UI.command_prompt = (function() {
         prompt_div.addClass("r-language-pseudo");
         ace.require("ace/ext/language_tools");
         var widget = ace.edit(prompt_div[0]);
+        ace_widget_ = widget;
         set_ace_height();
         var RMode = ace.require("ace/mode/r").Mode;
         var session = widget.getSession();
+        ace_session_ = session;
         var doc = session.doc;
         widget.setOptions({
             enableBasicAutocompletion: true
@@ -284,6 +288,13 @@ RCloud.UI.command_prompt = (function() {
                 return;
             entry_.widget.focus();
             entry_.restore();
+        },
+        get_selection: function() {
+            if(!show_prompt_) {
+                return undefined;
+            } else {
+                return ace_session_.doc.getTextRange(ace_widget_.selection.getRange());
+            }
         }
     };
     return result;

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -154,6 +154,7 @@ RCloud.UI.find_replace = (function() {
             replace_stuff_.show();
         else
             replace_stuff_.hide();
+
         build_regex(find_input_.val());
         highlight_all();
         shown_ = true;
@@ -189,6 +190,8 @@ RCloud.UI.find_replace = (function() {
         
         if(focussed_cell) {
             selection = focussed_cell.views[0].get_selection();
+        } else {
+            selection = RCloud.UI.command_prompt.get_selection();
         }
 
         return selection;
@@ -304,7 +307,9 @@ RCloud.UI.find_replace = (function() {
                         ['ctrl', 'f']
                     ]
                 },
-                action: function() { toggle_find_replace(false); }
+                action: function() { 
+                    toggle_find_replace(false); 
+                }
             }, {
                 category: 'Notebook Management',
                 id: 'notebook_replace',

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -106,28 +106,27 @@ RCloud.UI.shortcut_manager = (function() {
                     } else {
                         shortcut_to_add.create = function() {
                             _.each(shortcut_to_add.key_desc, function(binding) {
-                                window.Mousetrap(document.querySelector('body')).bind(binding, function(e) {
 
-                                    var func_to_bind = function(e) {
+                                var func_to_bind = function(e) {
 
-                                        if (is_active(get_by_id(shortcut_to_add.id))) {
-                                            e.preventDefault();
+                                    if (is_active(get_by_id(shortcut_to_add.id))) {
+                                        e.preventDefault();
 
-                                            // invoke if conditions are met:
-                                            if ((shortcut.enable_in_dialogs && $('.modal').is(':visible')) ||
-                                                !$('.modal').is(':visible')) {
-                                                shortcut.action(e);
-                                            }
-
+                                        // invoke if conditions are met:
+                                        if ((shortcut.enable_in_dialogs && $('.modal').is(':visible')) ||
+                                            !$('.modal').is(':visible')) {
+                                            shortcut.action(e);
                                         }
-                                    };
 
-                                    if (shortcut_to_add.global) {
-                                        window.Mousetrap.bindGlobal(binding, func_to_bind);
-                                    } else {
-                                        window.Mousetrap().bind(binding, func_to_bind);
                                     }
-                                });
+                                };
+
+                                if (shortcut_to_add.global) {
+                                    window.Mousetrap.bindGlobal(binding, func_to_bind);
+                                } else {
+                                    window.Mousetrap().bind(binding, func_to_bind);
+                                }
+
                             });
                         }
                     }


### PR DESCRIPTION
Whilst fixing issue #2042, I noticed something strange. Although I had modified the code, it wasn't working as I'd expected.

I found that shortcuts were being run _n_ times, where _n_ is the number of times that they have been invoked. :fearful:. I created a new issue #2043, and this PR fixes both the initial issue and #2043.

My logic for 'selection' is in this priority order:

1. Use cell selection from cell with focus. 0 or 1 of these.
2. Use prompt.

If neither have a selection, do nothing.

