### PR TITLE
Select all in find/replace field not working

### DIFF
--- a/htdocs/js/ui/command_prompt.js
+++ b/htdocs/js/ui/command_prompt.js
@@ -4,7 +4,9 @@ RCloud.UI.command_prompt = (function() {
         history_ = null,
         entry_ = null,
         language_ = null,
-        command_bar_ = null;
+        command_bar_ = null,
+        ace_widget_,
+        ace_session_;
 
     function setup_command_entry() {
         var prompt_div = $("#command-prompt");
@@ -20,9 +22,11 @@ RCloud.UI.command_prompt = (function() {
         prompt_div.addClass("r-language-pseudo");
         ace.require("ace/ext/language_tools");
         var widget = ace.edit(prompt_div[0]);
+        ace_widget_ = widget;
         set_ace_height();
         var RMode = ace.require("ace/mode/r").Mode;
         var session = widget.getSession();
+        ace_session_ = session;
         var doc = session.doc;
         widget.setOptions({
             enableBasicAutocompletion: true
@@ -284,6 +288,13 @@ RCloud.UI.command_prompt = (function() {
                 return;
             entry_.widget.focus();
             entry_.restore();
+        },
+        get_selection: function() {
+            if(!show_prompt_) {
+                return undefined;
+            } else {
+                return ace_session_.doc.getTextRange(ace_widget_.selection.getRange());
+            }
         }
     };
     return result;

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -154,6 +154,7 @@ RCloud.UI.find_replace = (function() {
             replace_stuff_.show();
         else
             replace_stuff_.hide();
+
         build_regex(find_input_.val());
         highlight_all();
         shown_ = true;
@@ -189,6 +190,8 @@ RCloud.UI.find_replace = (function() {
         
         if(focussed_cell) {
             selection = focussed_cell.views[0].get_selection();
+        } else {
+            selection = RCloud.UI.command_prompt.get_selection();
         }
 
         return selection;
@@ -304,7 +307,9 @@ RCloud.UI.find_replace = (function() {
                         ['ctrl', 'f']
                     ]
                 },
-                action: function() { toggle_find_replace(false); }
+                action: function() { 
+                    toggle_find_replace(false); 
+                }
             }, {
                 category: 'Notebook Management',
                 id: 'notebook_replace',

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -134,13 +134,19 @@ RCloud.UI.init = function() {
             ]
         },
         modes: ['writeable'],
-        action: function() {
-            var selection = window.getSelection();
-            selection.removeAllRanges();
-            var range = new Range();
-            range.selectNode(document.getElementById('output'));
-            range.setStartAfter($('.response')[0]);
-            selection.addRange(range);
+        action: function(e) {
+
+            if(!$(e.target).parents('#find-form').length) {
+                var selection = window.getSelection();
+                selection.removeAllRanges();
+                var range = new Range();
+                range.selectNode(document.getElementById('output'));
+                range.setStartAfter($('.response')[0]);
+                selection.addRange(range);
+            } else {
+                $(e.target).select();
+            }
+            
         }
     }, {
         category: 'Notebook Management',

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -106,28 +106,27 @@ RCloud.UI.shortcut_manager = (function() {
                     } else {
                         shortcut_to_add.create = function() {
                             _.each(shortcut_to_add.key_desc, function(binding) {
-                                window.Mousetrap(document.querySelector('body')).bind(binding, function(e) {
 
-                                    var func_to_bind = function(e) {
+                                var func_to_bind = function(e) {
 
-                                        if (is_active(get_by_id(shortcut_to_add.id))) {
-                                            e.preventDefault();
+                                    if (is_active(get_by_id(shortcut_to_add.id))) {
+                                        e.preventDefault();
 
-                                            // invoke if conditions are met:
-                                            if ((shortcut.enable_in_dialogs && $('.modal').is(':visible')) ||
-                                                !$('.modal').is(':visible')) {
-                                                shortcut.action(e);
-                                            }
-
+                                        // invoke if conditions are met:
+                                        if ((shortcut.enable_in_dialogs && $('.modal').is(':visible')) ||
+                                            !$('.modal').is(':visible')) {
+                                            shortcut.action(e);
                                         }
-                                    };
 
-                                    if (shortcut_to_add.global) {
-                                        window.Mousetrap.bindGlobal(binding, func_to_bind);
-                                    } else {
-                                        window.Mousetrap().bind(binding, func_to_bind);
                                     }
-                                });
+                                };
+
+                                if (shortcut_to_add.global) {
+                                    window.Mousetrap.bindGlobal(binding, func_to_bind);
+                                } else {
+                                    window.Mousetrap().bind(binding, func_to_bind);
+                                }
+
                             });
                         }
                     }


### PR DESCRIPTION
I branched from my local bug/2042 branch, because that fixes #2042 and #2043. Without that, this was awkward to test.

The last commit 2f38893 fixes this specific issue. 

Default 'mousetrap' key handling prevents shortcut invocation from input fields. This can be overridden by adding a `mousetrap` class to the element. This was done for find/replace text inputs so that find and replace could be toggled whilst within the field.

This meant that the default browser implementation of select all no longer worked. 

I guess the special case for these fields has now propagated to the select all shortcut in `init.js`. Not 100% ideal, but it's a special case, and hopefully will be the only example of such.