### PR TITLE
Focus out of find/replace form removes search matches

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -41,12 +41,13 @@ RCloud.UI.find_replace = (function() {
                 generate_matches();
             });
 
-            find_form_.on('focusout', function() {
+            find_form_.on('blur', function() {
+                console.log('blur');
                 has_focus_ = false;
                 clear_highlights();
             });
 
-            find_form_.on('focusin', function(e) {
+            find_form_.on('focus', function(e) {
                 if(!has_focus_) {
                     generate_matches(); 
                 }

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -41,13 +41,16 @@ RCloud.UI.find_replace = (function() {
                 generate_matches();
             });
 
-            find_form_.on('blur', function() {
-                console.log('blur');
-                has_focus_ = false;
-                clear_highlights();
+            find_form_.on('focusout', function(e) {
+                setTimeout(function() {
+                    if($(document.activeElement).closest(find_form_).length === 0) {
+                        has_focus_ = false;
+                        clear_highlights();
+                    }
+                }, 0);
             });
 
-            find_form_.on('focus', function(e) {
+            find_form_.on('focusin', function(e) {
                 if(!has_focus_) {
                     generate_matches(); 
                 }


### PR DESCRIPTION
Apologies - the earlier commit, 707207d, did not fix #2052. The second commit, 7a71d05, should do.

I'm using `document.activeElement` to determine which element has the focus.