### PR TITLE
Undo/redo available on edit, but not view page

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -178,8 +178,9 @@ RCloud.UI.init = function() {
                 ['ctrl', 'e']
             ]
         },
+        on_page: ['edit'],
         action: function() { 
-            if(shell.notebook.controller.is_mine() && !shell.is_view_mode()) {
+            if(shell.notebook.controller.is_mine()) {
                 editor.revert_notebook(shell.notebook.controller.is_mine(), shell.gistname(), shell.version());
             }
         }

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -150,7 +150,7 @@ RCloud.UI.init = function() {
                 ['ctrl', 'z']
             ]
         },
-        modes: ['writeable'],
+        on_page: ['edit'],
         action: function() { editor.step_history_undo(); }
     }, {
         category: 'Notebook Management',
@@ -164,7 +164,7 @@ RCloud.UI.init = function() {
                 ['ctrl', 'y']
             ]
         },        
-        modes: ['writeable'],
+        on_page: ['edit'],
         action: function() { editor.step_history_redo(); }
     }, {
         category: 'Notebook Management',

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -22,7 +22,9 @@ RCloud.UI.shortcut_manager = (function() {
     };
 
     function is_active(shortcut) {
-        return shortcut.enabled && _.contains(shortcut.modes, shell.notebook.model.read_only() ? 'readonly' : 'writeable');
+        return shortcut.enabled && 
+            _.contains(shortcut.modes, shell.notebook.model.read_only() ? 'readonly' : 'writeable') &&
+            _.contains(shortcut.on_page, shell.is_view_mode() ? 'view', 'edit');
     }
 
     function convert_extension(shortcuts) {

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -24,7 +24,7 @@ RCloud.UI.shortcut_manager = (function() {
     function is_active(shortcut) {
         return shortcut.enabled && 
             _.contains(shortcut.modes, shell.notebook.model.read_only() ? 'readonly' : 'writeable') &&
-            _.contains(shortcut.on_page, shell.is_view_mode() ? 'view', 'edit');
+            _.contains(shortcut.on_page, shell.is_view_mode() ? 'view' : 'edit');
     }
 
     function convert_extension(shortcuts) {

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -42,6 +42,7 @@ RCloud.UI.shortcut_manager = (function() {
             var shortcut_to_add = _.defaults(shortcut, {
                 category: 'General',
                 modes: ['writeable', 'readonly'],
+                on_page: ['view', 'edit'],
                 ignore_clash: false,
                 enable_in_dialogs: false,
                 enabled: true


### PR DESCRIPTION
This fixes #1899 with the introduction of a new `on_page` property in shortcuts, defaulting to an array of `['view', 'edit']`. This property value is checked in the shortcut manager's `is_active` function against `shell.is_view_mode()`. 

Undo/redo shortcuts have their `on_page` property value set to `['edit']`. This means that they are only active on the edit page, and should only show in the shortcuts dialog on the edit page.

I cleaned up the 'revert' shortcut, which had a check for the page... this has now been moved into that shortcut's `on_page` property`.