### PR TITLE
Lose focus when cell header is clicked

### DIFF
--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -90,7 +90,6 @@ function create_cell_html_view(language, cell_model) {
                 is_exclusive: !e.ctrlKey && !e.shiftKey
             });
 
-            // so that keyboard shortcuts work:
             $(':focus').blur();
 
         }).children().click(function(e) {

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -90,6 +90,9 @@ function create_cell_html_view(language, cell_model) {
                 is_exclusive: !e.ctrlKey && !e.shiftKey
             });
 
+            // so that keyboard shortcuts work:
+            $(':focus').blur();
+
         }).children().click(function(e) {
             var target = $(e.target);
             if(!target.hasClass('cell-number')) {


### PR DESCRIPTION
Lose focus of any element with focus, permitting delete shortcut to work as expected.