### PR TITLE
More shortcut fixes

### DIFF
--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -437,8 +437,8 @@ function create_cell_html_view(language, cell_model) {
         }, {
             name: 'executeAll',
             bindKey: {
-                win: 'Ctrl-u',
-                mac: 'Command-u',
+                win: 'Ctrl-Shift-Enter',
+                mac: 'Ctrl-Shift-Enter',
                 sender: 'editor'
             },
             exec: function() {

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -373,8 +373,8 @@ function create_cell_html_view(language, cell_model) {
         }, {
             name: 'navigateToPreviousCell',
             bindKey: {
-                win: 'Alt-Up',
-                mac: 'Alt-Up',
+                win: 'Ctrl-Shift-,',
+                mac: 'Ctrl-Shift-,',
                 sender: 'editor'
             },
             exec: function() {
@@ -387,8 +387,8 @@ function create_cell_html_view(language, cell_model) {
         }, {
             name: 'navigateToNextCell',
             bindKey: {
-                win: 'Alt-Down',
-                mac: 'Alt-Down',
+                win: 'Ctrl-Shift-.',
+                mac: 'Ctrl-Shift-.',
                 sender: 'editor'
             },
             exec: function() {

--- a/htdocs/js/ui/ace_shortcuts.js
+++ b/htdocs/js/ui/ace_shortcuts.js
@@ -578,29 +578,6 @@ RCloud.UI.ace_shortcuts = (function() {
             },
             {
                 category: 'Code Editor',
-                id: 'ace_scroll_line_down',
-                description: 'Scroll line down',
-                keys: { 
-                    mac: [
-                        ['command', 'down']
-                    ],
-                    win: [
-                        ['ctrl', 'down']
-                    ]
-                }
-            },
-            {
-                category: 'Code Editor',
-                id: 'ace_scroll_line_up',
-                description: 'Scroll line up',
-                keys: { 
-                    win: [
-                        ['ctrl', 'up']
-                    ]
-                }
-            },
-            {
-                category: 'Code Editor',
                 id: 'ace_go_to_matching_bracket',
                 description: 'Go to matching bracket',
                 keys: { 

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -266,7 +266,7 @@ RCloud.UI.init = function() {
         description: 'Go to previous cell',
         keys: {
             win_mac: [
-                ['alt', 'up']
+                ['ctrl', 'shift', '<']
             ]
         },
         modes: ['writeable']
@@ -276,7 +276,7 @@ RCloud.UI.init = function() {
         description: 'Go to next cell',
         keys: {
             win_mac: [
-                ['alt', 'down']
+                ['ctrl', 'shift', '>']
             ]
         },
         modes: ['writeable']

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -188,11 +188,8 @@ RCloud.UI.init = function() {
         id: 'notebook_run_all',
         description: 'Run all',
         keys: {
-            mac: [
-                ['command', 'u']
-            ],
-            win: [
-                ['ctrl', 'u']
+            win_mac: [
+                ['ctrl', 'shift', 'enter']
             ]
         },
         action: function() { RCloud.UI.run_button.run(); }


### PR DESCRIPTION
- Removed ctrl up/down (scroll lines up/down)
- Gave ACE alt up/down (move lines up/down) back. Remapped navigate previous next cell to 'ctrl-shift-,' and 'ctrl-shift-.' (ctrt-shift-< and ctrl-shift->).
- Gave ACE ctrl-u and ctrl-shift-u back. Remapped run all to 'ctrl-shift-enter'.
