### PR TITLE
Can now add members/admins to group

### DIFF
--- a/htdocs/js/ui/notebook_protection_controller.js
+++ b/htdocs/js/ui/notebook_protection_controller.js
@@ -52,6 +52,9 @@ define(['angular'], function(angular) {
             //general logic
             $scope.evalData()
             .then(function() {
+                return $scope.getUsers();
+            })
+            .then(function() {
                 return $scope.getGroups();
             })
             .then(function() {
@@ -94,6 +97,24 @@ define(['angular'], function(angular) {
 
         //NOTEBOOK TAB METHODS
         /////////////////////////////////////////
+        $scope.getUsers = function() {
+            return $q(function(resolve, reject) {
+                rcloud.get_users()
+                .then(function(data) {
+
+                    $scope.$evalAsync(function() {
+                        $scope.allUsers = _.map(data, function(user) { return { text : user, value : user }; });
+                    });
+
+                    //timeout to ensure evalAsync has finished
+                    $timeout(function() {
+                        logger.clear();
+                        resolve();
+                    }, 50);
+                });
+            });
+        };
+
         $scope.getGroups = function() {
             return $q(function(resolve, reject) {
                 GroupsService.getUsersGroups($scope.userName)

--- a/htdocs/js/ui/notebook_protection_controller.js
+++ b/htdocs/js/ui/notebook_protection_controller.js
@@ -27,7 +27,7 @@ define(['angular'], function(angular) {
         $scope.initialSharedStatus = '';
         $scope.initialGroupId = '';
 
-        $scope.allUsers = editor.allTheUsers;
+        $scope.allUsers = [];
         $scope.myConfig = { openOnFocus: false, closeAfterSelect: true };
 
         $scope.currentTab = null;


### PR DESCRIPTION
`editor.allTheUsers` _was_ used to initialise the users. Although that sounded about right, its value was undefined, and there was no code to get the users.

I have added a new scope level function to get the users. This wasn't enough, however, since I couldn't get things to work until I converted the names to selectize compatible format.

Becuase both selectize directives use the scope level `allUsers` member it works for both admins and members.