### PR TITLE
Discover Metric change indicator

### DIFF
--- a/htdocs/discover.html
+++ b/htdocs/discover.html
@@ -21,8 +21,10 @@
     </div>
 
     <div id="progress">
-      <img src="img/logo_rcloud.png" />
-      <div class="loader">Loading...</div>
+      <div>
+        <img src="img/logo_rcloud.png" />
+        <div class="loader">Loading...</div>
+      </div>
     </div>
 
     <div class="container" id="main-div">

--- a/htdocs/js/discovery_model.js
+++ b/htdocs/js/discovery_model.js
@@ -8,6 +8,14 @@ RCloud.discovery_model = function () {
         return obj;
     }
 
+    function temp() {
+        var deferred = Promise.pending();
+        setTimeout(function(){
+            deferred.resolve();
+        }, 5000);
+        return deferred.promise;
+    }
+
     return {
         get_notebooks : function(anonymous, notebook_ids) {
 
@@ -23,7 +31,8 @@ RCloud.discovery_model = function () {
                     rcloud.get_multiple_notebook_infos(ids),
                     rcloud.stars.get_multiple_notebook_star_counts(ids),
                     anonymous ? Promise.resolve([]) : rcloud.stars.get_my_starred_notebooks(),
-                    rcloud.get_multiple_fork_counts(ids)
+                    rcloud.get_multiple_fork_counts(ids),
+                    temp()
                 ]).spread(function(notebooks, stars, my_starred_notebooks, forks) {
                     notebooks = clean_r(notebooks);
 

--- a/htdocs/js/discovery_model.js
+++ b/htdocs/js/discovery_model.js
@@ -8,14 +8,6 @@ RCloud.discovery_model = function () {
         return obj;
     }
 
-    function temp() {
-        var deferred = Promise.pending();
-        setTimeout(function(){
-            deferred.resolve();
-        }, 5000);
-        return deferred.promise;
-    }
-
     return {
         get_notebooks : function(anonymous, notebook_ids) {
 
@@ -31,8 +23,7 @@ RCloud.discovery_model = function () {
                     rcloud.get_multiple_notebook_infos(ids),
                     rcloud.stars.get_multiple_notebook_star_counts(ids),
                     anonymous ? Promise.resolve([]) : rcloud.stars.get_my_starred_notebooks(),
-                    rcloud.get_multiple_fork_counts(ids),
-                    temp()
+                    rcloud.get_multiple_fork_counts(ids)
                 ]).spread(function(notebooks, stars, my_starred_notebooks, forks) {
                     notebooks = clean_r(notebooks);
 

--- a/htdocs/js/ui/discovery_page.js
+++ b/htdocs/js/ui/discovery_page.js
@@ -173,23 +173,8 @@ RCloud.UI.discovery_page = (function() {
                             });
 
                             if(!$('.body').hasClass('loaded')) {
-                                // $('#progress').fadeOut(200, function() {
-                                //     $('.navbar').fadeIn(200, function() {
-                                //         //$('.container').css({'opacity' : '1' });
-                                //         //$('#discovery-app').css('visibility', 'visible');
-                                //         $('body').addClass('loaded');
-                                //     });
-                                // });
-
                                 $('body').addClass('loaded');
-
-
-                            } else {
-                                // post initial load:
-                                // $('body').removeClass('loading');
-                                // $('#progress').hide();
-                                // $('.container').css({'opacity' : '1' });
-                            }
+                            } 
 
                             $('body').removeClass('loading');
                         });

--- a/htdocs/js/ui/discovery_page.js
+++ b/htdocs/js/ui/discovery_page.js
@@ -82,8 +82,7 @@ RCloud.UI.discovery_page = (function() {
             var data, missing_img = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAMAAAC3Ycb+AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAURQTFRF6PH06fH0+fv8w9fd+vz94+3xxtne5O7xwNXbx9nf9fn64u3w5/Dzwtbc5u/yxdjeydvgz9/k4ezv1eTo9vr73+vu3Ons8vf4+vz84+7x6/P13entx9rf5vDy7/X32efr9vn6wdbb3ert8vf5zd7jzN3i8/j59Pj51uTo8Pb48fb4zt/k0ODlytzh9/r7w9fc1+Xp0+LnwdXb1OPn2+js4ezw4Ozv7vT2yNrg2ebq6PHz6vL0xNjdy9zh2Obq2OXq2ufr0+Lm7fT20uLm6vL17PT25vDzyNvg+Pr73urt5/Hz8/f57vX36fL0+fz8xtnf8ff4zN7i1uXp9Pj6xNfd3Ojs3uru+Pv77PP1+Pv84Ovv1OPo0uHm0eHlzt7jy93i8Pb30ODk6/L17PP21ePo5O7yydvh5O/y0eHm4+3wv9Ta5e/yk3jLJAAACxdJREFUeNrs3f1bFNcVwPGjKLvruu4CAlKwCAFFgfAiWrWAUNpQkzZGY22jpmn63nv//9+rxii7DLszc8/MnNn5nufJ88TnYYZzzsfx7p25c1emxROGQuQ8IoY43l4fiBjyOC/iEbHk4cUjYsnjPQgidjx+AkHEjMcHEESsePwMgogRj48giNjw+ASCiAmPEyCIWPA4CYKIAY8uEESK9+gGQaRwjx4QRIr26AVBpGCPUyCIFOtxGgSRQj0iQBAp0iMKBJECPSJBECnOIxoEkcI8zgBBpCiPs0AQKcjjTBBEivE4GwSRQjz6gCBShEc/EEQK8OgLgkj+Hv1BEMndYwAIInl7DAJBJGePgSCI5OsxGASRXD1igCCSp0ccEERy9IgFgkh+HvFAEMnNIyYIInl5xAVBJCeP2CCI5OMRHwSRXDwSgCCSh0cSEERy8EgEgkj2HslAEMncIyEIIll7JAVBJOt+iUfEkkdyEESy7ZV4RCx5pAFBJMs+iUfEkkc6EESy65F4RCx5pAVBJKv+iEfEkkd6EESy6Y14RCx5hIAgkkVfxCNiySMMBBH9nohHxJJHKAgi2v0Qj4glj3AQRHR7IR4RSx4aIIho9kE8IpY8dEAQ0euBeERMdUA8IqbqF4+IqerFI2KqdvGImKpcPCKm6haPiKmqxSNiqmbxiJiqWDwipuoVj4ipasUjYqpW8YiYqlQ8IqbqFI+IqSrFI2KqRvGImKpQPCKm6hOPiKnqxCNiqjbxiJiqTDwipuoSj4ipqsQjYqom8YiYqkg8IqbqEY+IqWrEI2KqFvGImKpEPCKm6hCPiKkqxCNiqgbxiJiqQDwipvIXj4ip7MUjYip38YiYylw8IqbyFo+Iqax5v9waPy0AhAAEEAIQQAhAACEAAYQAhBhqkCdjoy5VtJcXAVGP2poLiLuAKMfFOeeGSKT0ILVAD+dmAdGMv4Z6uAeAKMa8C48/AaIWMyMKIMuAqMWWgoer1wDRGtE3+ne68S7aA0UeA6IUryMZlv95MPuq+a/uH202m5OTs1Pzb+qnjxgDROkCiRpB5u4PnNf3HrILiE48jLob8p/Bx021eg66B4hKLEeAvIpz4GbPQQ8B0YhmxHAwEu/fup6j1gDRiJWIC+Tf8Q7tGXzmANGI9QiQmOPzgtmZSIlBavWoD73/i3Pofbt3T0oMshM5yYs1p5joPep7QMLjv9HT7jifmObSfRYApG90IjQ2Go2lycHzEMN3T4oEqc0vNV44ozHSWN5vVgtkZcMZj4WtWnVAmh1Xgng6XhWQi21Xiti4XxGQjitJjM5UAmTFlSa+rwJIbaQ8INv3KgCy70oUExUAWSoTyHoFQBplAmlVAGSkTCAOkPd/L8c2n48tRI6yP0zsrxw+yA/kIiDO7b2/jzQeMV1Z+nCHabYBSH4gox9uIp1eKvr802fnPUByA/n4isDDPssRaqMD1i0uHW4uLi5Ovv1vZ2Ws8wKQ1CCfPtj0PKcdmRnwXOPn6Bydfio7/vjZCCCpQEY//ehGv/sYZ1wijYkzn2TsLG0DEgTS/aM73ecZizp4wCPDmZUXgKiB9PT68PTAsRrjfvlmGxAlkJ63mN+cGjomY/3+2t1tQFRANrvP07O4dyP+UoXxPUA0QH7oHg66P4J1mkly2KwDEg7i5k+epvsN3KOESUy2AQkHaZ24CromjfWDxFnMdAAJBnHtj5P4iZMDcyvN6/+1Z4AEgzj34/ulOVPHXTP4yXSJjAESDuLcbqPR/VJa62XaTJ4BogByajYYsF3JHiD6IPMBqdQagGiDhL0heH8BEF2QucAV0fuAqIJsB6+HXgVEEyR8HdugLYUASQLyVCGdx4DogUxp5PMAEC2QPZV8pgDRAlHawbIDiA5IRymhHUB0QA60MhoFRANkQy2ju4BogOhtq3QPEA2QJ3oprQMSDqK5Q8kEIOEgmruJjgMSDrKvmdMuIMEgqi8sLwESCrKhmtNrQEJBOqo57QASCqK7Q/g4IKEgyl9WVAckEGRTN6kNQAJBDnSTagMSCDKlm9QDQAABBJAMQXZ0k5oDJBBE+Vs/GNRDQZ7rJtUCJBDkSDWnGjP1UJAl1ZwmAQkF0f1enHlAQkG2VXM6AiT4AdVLzZzWAQkGUb3dWwckGERzR90pFjmEgywopnQIiMJCuXm9lNqAKIDofTX9IktJNUDqTa2MfgRE5XUErW8uqLUAUQHRWt37mhd2lF5p01no0P8LZgBJANJWyec5L32qvRatMYoM2DkAkCQgLYUV12tsHKC4tcaz4GyesNeJ6m5AodP1gTtmAZIMpBW4HdDAfRcBSbiB2YOgXObZUU59i7+Q9xJeLgCiDuIOU2cyHuP8gCQGST0bae46QLIASSkyHmv7d0BSgKRaNTcZ7+SApAFxq4k3J51qOUCyA3GN+8mS2Ip7YkDSgbiFJMvhm+sOkIxBnNuLPWmfWHCAZA/i6luxRpLFRN+jC0h6EOdad2cG/fbZ9WSnBOTko/K6SxqtN/1G99r+cdITAuLcx7HgiUsTxyvN6F+8s9pKfjZATtwuXHYpo702/6r70pi9u76d6lSAfLoVcuSCorG8unq4srK6unrcTn8WQN5F52Dm4sGcsxCAGAtAAAEEkBKFH36Qp2XyaFUAZKlMIMcVAHlcJpCtCoDUWuXxqI9XACT+07riY81XAaQ2VxaP3WYlQHyzJJ98FyZ9NUD8vVJcI7t5exQH4mtbC+bH87WLvjogb//Zmlg3PENsd7buFdCUIkEIQAAhAAGEAAQQAhBACEAIQAAhAAGEAAQQAhBACEAIQAAhAAGEAAQQYqhBbn9+xWRPzl04V0mQ21evGP1bWqSI4GFLRPCwJVIUyJ2rtsfWwkQED1sigoctEcHDlkgRIHdulGOOVohIASDflMSjGBHBw5ZI7iDTJfIoQkTwsCWSM8j0Je8RsQNSPo/cRXIF+ayEHnmLCB62RAQPWyKChy0RwcOWSF4gX5XaI0cRwcOWSD4gN7/1HhE7IMPgkZdIHiA3b3mPiB2QYfHIR0TwsCWSOcitIfLIQ0TwsCWSMcitm94jYgdk+DwyF8kU5Nsh9MhaRPCwJZIhyKWvvEfEDsjwemQqkhnIpc+8R8QOyHB7ZCgieNgSETxsiQgetkSyALk07T0idkCq4pGNiOBhS0Qd5EaFPLIQETxsiSiD3PjGe0TsgFTPQ11EFeTGHe8RsQNytZIeyiKChy0RwcOWiBbIlau3vUfEDEjFPRRFBA9bIiogVz6vvIeaiOBhS0Q0PP6GhpqI4GFLRMI9fomEoojgYUtE8LAlEgZy5fd4KIsIHrZEQkCu46EvInjYEkkPcp3xPAsR4fqwJZIW5Pqf8chERNJ6/IGuZyIieNgSSQVy/Ts8shIRPGyJpAC5fv5XdDszEcHDlkhikC/wyFRE8LAlkhDki+/wyFZEuD5siQgetkSSgFw+/xv6m7WI4GFLRPCwJSJ42BIRPGyJCB62RCSmx+/oaT4igoctEcHDlojgYUtE8LAlIoM9/kEncxQRPGyJyCCPv9DFXEX6g1z+Go+cRQQPWyL9QC5f+wX9y1tE8LAlcjbIl3gUISJ42BI5C+TLr/EoRES4PmyJRIM8wqMoEcHDlkgUyCPGj+JEhOvDlojgYUvkFMijC3+nUwWKCB62RHpA5MJv6VKhIoKHLZEuELmGR9EiwvVhS0TwsCUiJzx+TW+KFxE8bInIx/EcDxMiwvVhS0TwsCUiP/0BDysigoctEXn3P3+kG2ZExJ+7hochEeH6sCUieJgSmf6/AAMAF4/8wMtS1yoAAAAASUVORK5CYII=';
             current_metric = current_metric || 'recently.modified';
 
-            $('#progress').show();
-            $('.container').css({'opacity' : '0.05' });
+            $('body').addClass('loading');
 
             var anonymous = !rcloud.username();
 
@@ -173,19 +172,26 @@ RCloud.UI.discovery_page = (function() {
                                 transitionDuration: 0
                             });
 
-                            if($('#progress').is(':visible') && !$('.body').hasClass('loaded')) {
-                                $('#progress').fadeOut(200, function() {
-                                    $('.navbar').fadeIn(200, function() {
-                                        $('.container').css({'opacity' : '1' });
-                                        $('#discovery-app').css('visibility', 'visible');
-                                        $('body').addClass('loaded');
-                                    });
-                                });
+                            if(!$('.body').hasClass('loaded')) {
+                                // $('#progress').fadeOut(200, function() {
+                                //     $('.navbar').fadeIn(200, function() {
+                                //         //$('.container').css({'opacity' : '1' });
+                                //         //$('#discovery-app').css('visibility', 'visible');
+                                //         $('body').addClass('loaded');
+                                //     });
+                                // });
+
+                                $('body').addClass('loaded');
+
+
                             } else {
                                 // post initial load:
-                                $('#progress').hide();
-                                $('.container').css({'opacity' : '1' });
+                                // $('body').removeClass('loading');
+                                // $('#progress').hide();
+                                // $('.container').css({'opacity' : '1' });
                             }
+
+                            $('body').removeClass('loading');
                         });
                 });
             });

--- a/htdocs/js/ui/discovery_page.js
+++ b/htdocs/js/ui/discovery_page.js
@@ -82,6 +82,8 @@ RCloud.UI.discovery_page = (function() {
             var data, missing_img = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZAAAAGQCAMAAAC3Ycb+AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAURQTFRF6PH06fH0+fv8w9fd+vz94+3xxtne5O7xwNXbx9nf9fn64u3w5/Dzwtbc5u/yxdjeydvgz9/k4ezv1eTo9vr73+vu3Ons8vf4+vz84+7x6/P13entx9rf5vDy7/X32efr9vn6wdbb3ert8vf5zd7jzN3i8/j59Pj51uTo8Pb48fb4zt/k0ODlytzh9/r7w9fc1+Xp0+LnwdXb1OPn2+js4ezw4Ozv7vT2yNrg2ebq6PHz6vL0xNjdy9zh2Obq2OXq2ufr0+Lm7fT20uLm6vL17PT25vDzyNvg+Pr73urt5/Hz8/f57vX36fL0+fz8xtnf8ff4zN7i1uXp9Pj6xNfd3Ojs3uru+Pv77PP1+Pv84Ovv1OPo0uHm0eHlzt7jy93i8Pb30ODk6/L17PP21ePo5O7yydvh5O/y0eHm4+3wv9Ta5e/yk3jLJAAACxdJREFUeNrs3f1bFNcVwPGjKLvruu4CAlKwCAFFgfAiWrWAUNpQkzZGY22jpmn63nv//9+rxii7DLszc8/MnNn5nufJ88TnYYZzzsfx7p25c1emxROGQuQ8IoY43l4fiBjyOC/iEbHk4cUjYsnjPQgidjx+AkHEjMcHEESsePwMgogRj48giNjw+ASCiAmPEyCIWPA4CYKIAY8uEESK9+gGQaRwjx4QRIr26AVBpGCPUyCIFOtxGgSRQj0iQBAp0iMKBJECPSJBECnOIxoEkcI8zgBBpCiPs0AQKcjjTBBEivE4GwSRQjz6gCBShEc/EEQK8OgLgkj+Hv1BEMndYwAIInl7DAJBJGePgSCI5OsxGASRXD1igCCSp0ccEERy9IgFgkh+HvFAEMnNIyYIInl5xAVBJCeP2CCI5OMRHwSRXDwSgCCSh0cSEERy8EgEgkj2HslAEMncIyEIIll7JAVBJOt+iUfEkkdyEESy7ZV4RCx5pAFBJMs+iUfEkkc6EESy65F4RCx5pAVBJKv+iEfEkkd6EESy6Y14RCx5hIAgkkVfxCNiySMMBBH9nohHxJJHKAgi2v0Qj4glj3AQRHR7IR4RSx4aIIho9kE8IpY8dEAQ0euBeERMdUA8IqbqF4+IqerFI2KqdvGImKpcPCKm6haPiKmqxSNiqmbxiJiqWDwipuoVj4ipasUjYqpW8YiYqlQ8IqbqFI+IqSrFI2KqRvGImKpQPCKm6hOPiKnqxCNiqjbxiJiqTDwipuoSj4ipqsQjYqom8YiYqkg8IqbqEY+IqWrEI2KqFvGImKpEPCKm6hCPiKkqxCNiqgbxiJiqQDwipvIXj4ip7MUjYip38YiYylw8IqbyFo+Iqax5v9waPy0AhAAEEAIQQAhAACEAAYQAhBhqkCdjoy5VtJcXAVGP2poLiLuAKMfFOeeGSKT0ILVAD+dmAdGMv4Z6uAeAKMa8C48/AaIWMyMKIMuAqMWWgoer1wDRGtE3+ne68S7aA0UeA6IUryMZlv95MPuq+a/uH202m5OTs1Pzb+qnjxgDROkCiRpB5u4PnNf3HrILiE48jLob8p/Bx021eg66B4hKLEeAvIpz4GbPQQ8B0YhmxHAwEu/fup6j1gDRiJWIC+Tf8Q7tGXzmANGI9QiQmOPzgtmZSIlBavWoD73/i3Pofbt3T0oMshM5yYs1p5joPep7QMLjv9HT7jifmObSfRYApG90IjQ2Go2lycHzEMN3T4oEqc0vNV44ozHSWN5vVgtkZcMZj4WtWnVAmh1Xgng6XhWQi21Xiti4XxGQjitJjM5UAmTFlSa+rwJIbaQ8INv3KgCy70oUExUAWSoTyHoFQBplAmlVAGSkTCAOkPd/L8c2n48tRI6yP0zsrxw+yA/kIiDO7b2/jzQeMV1Z+nCHabYBSH4gox9uIp1eKvr802fnPUByA/n4isDDPssRaqMD1i0uHW4uLi5Ovv1vZ2Ws8wKQ1CCfPtj0PKcdmRnwXOPn6Bydfio7/vjZCCCpQEY//ehGv/sYZ1wijYkzn2TsLG0DEgTS/aM73ecZizp4wCPDmZUXgKiB9PT68PTAsRrjfvlmGxAlkJ63mN+cGjomY/3+2t1tQFRANrvP07O4dyP+UoXxPUA0QH7oHg66P4J1mkly2KwDEg7i5k+epvsN3KOESUy2AQkHaZ24CromjfWDxFnMdAAJBnHtj5P4iZMDcyvN6/+1Z4AEgzj34/ulOVPHXTP4yXSJjAESDuLcbqPR/VJa62XaTJ4BogByajYYsF3JHiD6IPMBqdQagGiDhL0heH8BEF2QucAV0fuAqIJsB6+HXgVEEyR8HdugLYUASQLyVCGdx4DogUxp5PMAEC2QPZV8pgDRAlHawbIDiA5IRymhHUB0QA60MhoFRANkQy2ju4BogOhtq3QPEA2QJ3oprQMSDqK5Q8kEIOEgmruJjgMSDrKvmdMuIMEgqi8sLwESCrKhmtNrQEJBOqo57QASCqK7Q/g4IKEgyl9WVAckEGRTN6kNQAJBDnSTagMSCDKlm9QDQAABBJAMQXZ0k5oDJBBE+Vs/GNRDQZ7rJtUCJBDkSDWnGjP1UJAl1ZwmAQkF0f1enHlAQkG2VXM6AiT4AdVLzZzWAQkGUb3dWwckGERzR90pFjmEgywopnQIiMJCuXm9lNqAKIDofTX9IktJNUDqTa2MfgRE5XUErW8uqLUAUQHRWt37mhd2lF5p01no0P8LZgBJANJWyec5L32qvRatMYoM2DkAkCQgLYUV12tsHKC4tcaz4GyesNeJ6m5AodP1gTtmAZIMpBW4HdDAfRcBSbiB2YOgXObZUU59i7+Q9xJeLgCiDuIOU2cyHuP8gCQGST0bae46QLIASSkyHmv7d0BSgKRaNTcZ7+SApAFxq4k3J51qOUCyA3GN+8mS2Ip7YkDSgbiFJMvhm+sOkIxBnNuLPWmfWHCAZA/i6luxRpLFRN+jC0h6EOdad2cG/fbZ9WSnBOTko/K6SxqtN/1G99r+cdITAuLcx7HgiUsTxyvN6F+8s9pKfjZATtwuXHYpo702/6r70pi9u76d6lSAfLoVcuSCorG8unq4srK6unrcTn8WQN5F52Dm4sGcsxCAGAtAAAEEkBKFH36Qp2XyaFUAZKlMIMcVAHlcJpCtCoDUWuXxqI9XACT+07riY81XAaQ2VxaP3WYlQHyzJJ98FyZ9NUD8vVJcI7t5exQH4mtbC+bH87WLvjogb//Zmlg3PENsd7buFdCUIkEIQAAhAAGEAAQQAhBACEAIQAAhAAGEAAQQAhBACEAIQAAhAAGEAAQQYqhBbn9+xWRPzl04V0mQ21evGP1bWqSI4GFLRPCwJVIUyJ2rtsfWwkQED1sigoctEcHDlkgRIHdulGOOVohIASDflMSjGBHBw5ZI7iDTJfIoQkTwsCWSM8j0Je8RsQNSPo/cRXIF+ayEHnmLCB62RAQPWyKChy0RwcOWSF4gX5XaI0cRwcOWSD4gN7/1HhE7IMPgkZdIHiA3b3mPiB2QYfHIR0TwsCWSOcitIfLIQ0TwsCWSMcitm94jYgdk+DwyF8kU5Nsh9MhaRPCwJZIhyKWvvEfEDsjwemQqkhnIpc+8R8QOyHB7ZCgieNgSETxsiQgetkSyALk07T0idkCq4pGNiOBhS0Qd5EaFPLIQETxsiSiD3PjGe0TsgFTPQ11EFeTGHe8RsQNytZIeyiKChy0RwcOWiBbIlau3vUfEDEjFPRRFBA9bIiogVz6vvIeaiOBhS0Q0PP6GhpqI4GFLRMI9fomEoojgYUtE8LAlEgZy5fd4KIsIHrZEQkCu46EvInjYEkkPcp3xPAsR4fqwJZIW5Pqf8chERNJ6/IGuZyIieNgSSQVy/Ts8shIRPGyJpAC5fv5XdDszEcHDlkhikC/wyFRE8LAlkhDki+/wyFZEuD5siQgetkSSgFw+/xv6m7WI4GFLRPCwJSJ42BIRPGyJCB62RCSmx+/oaT4igoctEcHDlojgYUtE8LAlIoM9/kEncxQRPGyJyCCPv9DFXEX6g1z+Go+cRQQPWyL9QC5f+wX9y1tE8LAlcjbIl3gUISJ42BI5C+TLr/EoRES4PmyJRIM8wqMoEcHDlkgUyCPGj+JEhOvDlojgYUvkFMijC3+nUwWKCB62RHpA5MJv6VKhIoKHLZEuELmGR9EiwvVhS0TwsCUiJzx+TW+KFxE8bInIx/EcDxMiwvVhS0TwsCUiP/0BDysigoctEXn3P3+kG2ZExJ+7hochEeH6sCUieJgSmf6/AAMAF4/8wMtS1yoAAAAASUVORK5CYII=';
             current_metric = current_metric || 'recently.modified';
 
+            $('#progress').show();
+            $('.container').css({'opacity' : '0.05' });
 
             var anonymous = !rcloud.username();
 
@@ -171,13 +173,18 @@ RCloud.UI.discovery_page = (function() {
                                 transitionDuration: 0
                             });
 
-                            if($('#progress').is(':visible')) {
+                            if($('#progress').is(':visible') && !$('.body').hasClass('loaded')) {
                                 $('#progress').fadeOut(200, function() {
                                     $('.navbar').fadeIn(200, function() {
+                                        $('.container').css({'opacity' : '1' });
                                         $('#discovery-app').css('visibility', 'visible');
                                         $('body').addClass('loaded');
                                     });
                                 });
+                            } else {
+                                // post initial load:
+                                $('#progress').hide();
+                                $('.container').css({'opacity' : '1' });
                             }
                         });
                 });

--- a/htdocs/js/ui/discovery_page.js
+++ b/htdocs/js/ui/discovery_page.js
@@ -177,6 +177,7 @@ RCloud.UI.discovery_page = (function() {
                             } 
 
                             $('body').removeClass('loading');
+
                         });
                 });
             });
@@ -196,7 +197,11 @@ RCloud.UI.discovery_page = (function() {
 
                     metric.init({
                         change: function(metric) {
-                            discovery.load_current_metric(metric);
+                            $("html, body").animate({
+                                scrollTop: 0
+                            }, 250, function() {
+                                discovery.load_current_metric(metric);    
+                            });
                         },
                         oncomplete: function(metric) {
                             resolve(discovery.load_current_metric(metric));

--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -80,14 +80,17 @@ body {
 }
 
 #progress {
-    height: 180px;
+    height: 230px;
     position: absolute;
     top: 48%;
     margin-top: -90px;
     text-align: center;
-    width: 500px;
-    margin-left: -250px;
+    width: 550px;
+    margin-left: -275px;
     left: 50%;
+    padding-top: 25px;
+    background: white;
+    z-index: 1000;
 }
 
 .loader:before,

--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -37,15 +37,6 @@
     }
 }
 
-body {
-    overflow: hidden;
-    &.loaded {
-        overflow: auto;
-        background: #c7d6e2;
-        padding-top: 40px;
-    }
-}
-
 @media (max-width: 767px) {
     body.loaded {
         padding-top: 95px;
@@ -80,17 +71,52 @@ body {
 }
 
 #progress {
-    height: 230px;
+    height: 100%;
     position: absolute;
-    top: 48%;
-    margin-top: -90px;
     text-align: center;
-    width: 550px;
-    margin-left: -275px;
-    left: 50%;
-    padding-top: 25px;
     background: white;
     z-index: 1000;
+    top: 0;
+    width: 100%;
+    opacity: 0.9;
+
+    > div {
+        top: 50%;
+        position: absolute;
+        margin-top: -90px;
+        margin-left: -229px;
+        left: 50%;
+        //opacity: 1;
+    }
+}
+
+body {
+    &.loaded {
+        overflow: auto;
+        background: #c7d6e2;
+        padding-top: 40px;
+
+        .navbar {
+            display: block;
+        }
+
+        #discovery-app {
+            visibility: visible;
+        }
+
+        #progress {
+            display: none;
+        }
+
+        &.loading {
+            overflow: hidden;
+
+            #progress {
+                display: block;
+                //opacity: 0.7;
+            }
+        }
+    }
 }
 
 .loader:before,


### PR DESCRIPTION
The existing loader has been modified so that it overlays the entire screen. This prevents the user clicking the metric links whilst things are loading.

Scroll to top code has been implemented too, so the user doesn't have to scroll to the top manually after the metric has changed.

Locally, it's quite fast, so to simulate a long-running process, I added a setTimeout. Removed it in 	4007a06.