### PR TITLE
Shortcuts disabled when error occurs on view

### DIFF
--- a/htdocs/edit.js
+++ b/htdocs/edit.js
@@ -46,6 +46,9 @@ function main() {
         }).then(shell.init.bind(shell))
             .then(editor.init.bind(editor, opts));
     }).catch(function(error) {
+
+        RCloud.UI.shortcut_manager.disable_all();
+
         if (error.message === "Authentication required") {
             RCloud.UI.session_pane.post_error(ui_utils.disconnection_error("Please login first!"));
         } else

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -197,6 +197,9 @@ RCloud.UI.shortcut_manager = (function() {
                 s.enabled = false;
             });
         },
+        disable_all: function() {
+            this.disable(_.pluck(extension_.sections.all.entries, 'id'));
+        },
         enable: function(ids) {
             modify(ids, function(s) {
                 s.enabled = true;

--- a/htdocs/view.js
+++ b/htdocs/view.js
@@ -73,7 +73,11 @@ function main() {
         });
         return promise;
     }).catch(function(err) {
+
+        RCloud.UI.shortcut_manager.disable_all();
+
         console.log(err.stack);
+        
         shell.improve_load_error(err, notebook, version).then(function(msg) {
             if(/Notebook does not exist or has not been published/.test(msg))
                 msg = ui_utils.disconnection_error("Could not load notebook. You may need to login to see it.", "Login");


### PR DESCRIPTION
This fixes #1873. Added a 'disable all' method to the shortcut manager.

This method is invoked when a serious error occurs on view/edit.