### PR TITLE
Fixed Grunt issues

### DIFF
--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -2,14 +2,14 @@
     @if $viewport-max-width=="nomax" {
         @media (min-width: #{$viewport-min-width}px) {
             .grid-item {
-                width: #{$item-width}%;
+                width: #{$item-width}#{%};
             }
         }
     }
     @else {
         @media (min-width: #{$viewport-min-width}px) and (max-width: #{$viewport-max-width}px) {
             .grid-item {
-                width: #{$item-width}%;
+                width: #{$item-width}#{%};
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "devDependencies": {
     "grunt-cli": "~0.1.13",
-    "grunt-contrib-compress": "~1.0.0",
+    "grunt-contrib-compress": "~1.3.0",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-sass": "~1.1.0",
     "grunt-contrib-uglify": "~0.9.1",


### PR DESCRIPTION
This fixes 2 issues:

1. invalid syntax for the `rcloud-discover.scss` file (for newer versions of grunt-sass than I had, seen by @gaborcsardi on a fresh install);
2. `grunt.util._.include` is not a function: I saw this when I got past that first sass step; it was a [grunt-contrib-compress issue](https://github.com/gruntjs/grunt-contrib-compress/issues/177). Fixed with a version bump to 1.3.0.

`npm install` should bump it up locally and the issues are resolved.

