### PR TITLE
No duplicate notebook names (in folders)

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -166,8 +166,8 @@ var editor = function () {
     function find_next_copy_name(username, description) {
         var promise;
         var pid = node_id("alls", username);
-        if(description.indexOf('/')!==-1)
-            pid += '/' + description.replace(/\/[^\/]*$/,'');
+
+        // load all 'alls' for given username:
         var parent = $tree_.tree('getNodeById', pid);
         if(parent === undefined)
             return description;
@@ -181,6 +181,13 @@ var editor = function () {
         }
 
         return promise_load.then(function() {
+
+            // if this is folder level, get the actual parent for comparison:
+            if(description.indexOf('/')!==-1) {
+                pid += '/' + description.replace(/\/[^\/]*$/,'');
+                parent = $tree_.tree('getNodeById', pid);
+            }
+
             var map = _.object(_.map(parent.children, function(c) { return [c.full_name, true]; }));
             if(!map[description])
                 return description;


### PR DESCRIPTION
`find_next_copy_name` worked fine if the notebook was at root level, since the `lazy_load` check caused its child elements to load.

If there was a folder name, it would look at that parent node, which didn't have the `lazy_load` flag set, so no loading of child elements.

So, the code has been changed so that the 'root' node is loaded if necessary.

After that, the actual parent is used for notebook name comparison.