### PR TITLE
Default panel size setting does agree with actual layout

### DIFF
--- a/htdocs/js/ui/panel_loader.js
+++ b/htdocs/js/ui/panel_loader.js
@@ -197,7 +197,13 @@ RCloud.UI.panel_loader = (function() {
             }
 
             // alternative layout?
-            return rcloud.config.get_user_option('panel-layout-by-size').then(function(layoutBySize) {                
+            return rcloud.config.get_user_option('panel-layout-by-size').then(function(layoutBySize) {    
+
+                // default to true:
+                if(_.isNull(layoutBySize) || _.isUndefined(layoutBySize)) {
+                    layoutBySize = true;
+                }
+
                 if(!layoutBySize) {
 
                     var update_panel = function update_panel(panel, side, sort) {


### PR DESCRIPTION
Perhaps this doesn't need the _.isUndefined(...) because after running 

````r
rcs.rm(usr.key(notebook='system', 'config', 'panel-layout-by-size'))
````

I get `null` as the resolved value.