### PR TITLE
Discover small thumbs and fork/star titles

### DIFF
--- a/htdocs/discover.html
+++ b/htdocs/discover.html
@@ -47,10 +47,10 @@
             <% } %>
             <h2><%=notebook.last_commit%> by <%=notebook.username%></h2>
             <div class="buttons">
-              <button class="fork" title="Fork" type="button" class="btn btn-link navbar-btn">
+              <button class="fork" title="Fork count" type="button" class="btn btn-link navbar-btn">
                 <i class="icon-code-fork"></i><sub><%=notebook.forks%></sub>
               </button>
-              <button class="star" title="Add to Interests" type="button" class="btn btn-link navbar-btn">
+              <button class="star" title="Star count" type="button" class="btn btn-link navbar-btn">
                 <i class="<%=notebook.star_icon%>"></i><sub><%=notebook.stars%></sub>
               </button>
             </div>

--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -174,6 +174,7 @@ body {
     a {
         text-decoration: none;
         color: black;
+        display: block;
     }
     h1 {
         font-size: 17px;

--- a/htdocs/sass/rcloud-discover.scss
+++ b/htdocs/sass/rcloud-discover.scss
@@ -163,6 +163,7 @@ body {
 }
 
 .grid-item {
+    background-color: #e5eff2;
     color: black;
     margin-top: 0;
     width: 100%;


### PR DESCRIPTION
Changed the background of the tile so it looks better when the thumb's width is less than that of the tile. 

![image](https://cloud.githubusercontent.com/assets/2493614/16519458/098a8b60-3f81-11e6-80f6-b0658d58a8d3.png)

Made the entire tile clickable.

Also changed the fork/star titles because they (especially the star) implied that something could be done by clicking them (over and above opening that notebook.)