### PR TITLE
Don't always scroll to current notebook

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -837,9 +837,14 @@ var editor = function () {
         ui_utils.scroll_into_view($tree_.parent(), 50, 100, $(node.element));
     }
 
-    function select_node(node) {
+    function select_node(node, scroll) {
         $tree_.tree('selectNode', node);
-        scroll_into_view(node);
+
+        // scroll by default:
+        if(_.isUndefined(scroll) || scroll) {
+            scroll_into_view(node);
+        }
+
         if(node.user === username_)
             RCloud.UI.notebook_title.make_editable(node, node.element, true);
         else
@@ -1121,8 +1126,9 @@ var editor = function () {
                 var node_to_select = $tree_.tree('getNodeById', selected_node.id);
 
                 if(node_to_select)
-                    select_node(node_to_select);
-                else console.log('sorry, neglected to highlight ' + selected_node.id);
+                    select_node(node_to_select, false);
+                else 
+                    console.log('sorry, neglected to highlight ' + selected_node.id);
             }
 
             delete for_node.lazy_load;


### PR DESCRIPTION
There are several situations where selecting a node should mean that it scrolls into view.

The lazy loading for children should not need to scroll because a different node has not been selected.

Updated the `select_node` function so that by default it scrolls by default. If passed a falsey value for the `scroll` parameter, it does not scroll. A `false` value is passed in when called from the `load_lazy_children` function.