### PR TITLE
Lazy load users notebooks

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1131,28 +1131,6 @@ var editor = function () {
     function tree_open(event) {
         var n = event.node;
 
-        function create_book_entry_map(books) {
-            return _.chain(books)
-                .filter(function(book) {
-                    var entry = notebook_info_[book];
-                    if(!entry) {
-                        invalid_notebooks_[book] = null;
-                        return false;
-                    }
-                    if(!entry.username || entry.username === "undefined" ||
-                       !entry.description || !entry.last_commit) {
-                        invalid_notebooks_[book] = entry;
-                        return false;
-                    }
-                    return true;
-                })
-                .map(function(book) {
-                    var entry = notebook_info_[book];
-                    return [book, entry];
-                })
-                .object().value();
-        }
-
         // notebook folder name only editable when open
         if(n.full_name && n.user === username_ && !n.gistname)
             RCloud.UI.notebook_title.make_editable(n, n.element, true);

--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -447,7 +447,7 @@ var editor = function () {
         return function(datum) {
             if(datum.delay_children)
                 load_children(datum);
-            var d2 = _.pick(datum, "label", "name", "full_name", "gistname", "user", "visible", "source", "last_commit", "sort_order");
+            var d2 = _.pick(datum, "label", "name", "full_name", "gistname", "user", "visible", "source", "last_commit", "sort_order", "version");
             d2.id = datum.id.replace(srcroot, '/'+destroot+'/');
             d2.root = destroot;
             return d2;

--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1155,16 +1155,17 @@ var editor = function () {
         reselect_node(function() {
             return load_lazy_children(n).then(function() {
                 // notebook folder name only editable when open
-                if(event.node.full_name && event.node.user === username_ && !event.node.gistname)
-                    RCloud.UI.notebook_title.make_editable(event.node, event.node.element, true);
+                if(n.full_name && n.user === username_ && !n.gistname)
+                    RCloud.UI.notebook_title.make_editable(n, n.element, true);
                 $('#collapse-notebook-tree').trigger('size-changed');
             });
         });
     }
     function tree_close(event) {
+        var n = event.node;
         // notebook folder name only editable when open
-        if(event.node.full_name && !event.node.gistname)
-            RCloud.UI.notebook_title.make_editable(event.node, event.node.element, false);
+        if(n.full_name && !n.gistname)
+            RCloud.UI.notebook_title.make_editable(n, n.element, false);
     }
     var NOTEBOOK_LOAD_FAILS = 5;
     function open_last_loadable() {

--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -169,7 +169,7 @@ var editor = function () {
         // load all 'alls' for given username:
         var root = $tree_.tree('getNodeById', pid);
 
-        return load_lazy_children(root).return(root);
+        return load_lazy_children(root);
     }
 
     // way too subtle. shamelessly copying OSX Finder behavior here (because they're right).
@@ -1123,6 +1123,7 @@ var editor = function () {
             $tree_.tree('loadData', as_folder_hierarchy(notebook_nodes, node_id(for_node.root, for_node.user)).sort(compare_nodes), for_node);
 
             delete for_node.lazy_load;
+            return for_node;
         });
     }
 


### PR DESCRIPTION
This replaces #2157 

Opening this PR to facilitate code review because this is a big change with many commits (and still not quite done).

While fixing #2144 I noticed that the code could be a lot cleaner and clearer if we follow the MVC pattern more stringently. Sure, all the code is still mixed up in editor_tab.js, but the model is `notebook_info_` and a few other members, the view is the jqTree, and the controller.. well the metaphor breaks down because the controller code is all over the place, but we have M and V anyway.

I'm wary of checking in such a big change during the release, but this seems to work well and I think it will be more robust going forward, instead of fixing each place where a second stage of loading

This is really all ramifications of be80cf069064, cleaning up code at the later stages. If the data is good when the model is opened, there's no need to reselect the current node, so we don't have to worry about the scrolling in the lazy-load code.

Instead of keeping a flag on the tree to remember that we need to load it, loading is per-user and happens before the `notebook_info_` is updated with the current notebook's metadata.

Finally, we update People I Starred whenever All Notebooks is loaded.