### PR TITLE
htmlwidgets: remove periodic resize checker, closes #2162

### DIFF
--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -78,6 +78,12 @@
 ##
 ## # Sizing
 ##
+## [ NOTE: Currently we turned off the periodic size check that ran every
+## five minutes. It generates an infinite loop for some widgets:
+## plotly, networkd3 and dygraphs. In theory this might mean that
+## some widgets might not size properly, especially in mini.html.
+## A possible workaround is to resize the window (again) by hand. ]
+##
 ## Sizing of html widgets is tricky by itself. See the vignette in the
 ## R package, currently here:
 ## https://cran.r-project.org/web/packages/htmlwidgets/vignettes/develop_sizing.html

--- a/rcloud.support/inst/javascript/htmlwidgets.js
+++ b/rcloud.support/inst/javascript/htmlwidgets.js
@@ -47,9 +47,7 @@ $(document).ready(function() {
     add_hooks()
     function resizer() {
         var num_widgets = resize_all();
-        var interval = 200;
-        if (num_widgets > 0) { interval = 5000; }
-        setTimeout(resizer, interval);
+        if (num_widgets == 0) { setTimeout(resizer, 200); }
     }
     resizer()
 });

--- a/rcloud.support/inst/javascript/htmlwidgets.js
+++ b/rcloud.support/inst/javascript/htmlwidgets.js
@@ -9,9 +9,8 @@ function getDocHeight(D) {
 
 function size_this(div) {
     var D = $(div).find('iframe').contents()[0];
-    var B = D.body;
 
-    if (!B) {
+    if (!D || !D.body) {
         setTimeout(function() { size_this($(div)); }, 100);
     } else {
         var h = getDocHeight(D);


### PR DESCRIPTION
It might result an infinite resize loop for some widgets. Hopefully this solves #2162.