### PR TITLE
"Fix" htmlwidgets sizing

### DIFF
--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -78,12 +78,6 @@
 ##
 ## # Sizing
 ##
-## [ NOTE: Currently we turned off the periodic size check that ran every
-## five seconds. It generates an infinite loop for some widgets:
-## plotly, networkd3 and dygraphs. In theory this might mean that
-## some widgets might not size properly, especially in mini.html.
-## A possible workaround is to resize the window (again) by hand. ]
-##
 ## Sizing of html widgets is tricky by itself. See the vignette in the
 ## R package, currently here:
 ## https://cran.r-project.org/web/packages/htmlwidgets/vignettes/develop_sizing.html

--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -202,14 +202,14 @@ rcloud.htmlwidgets.viewer <- function(url, height) {
   invisible()
 }
 
-as.character.htmlwidget <- function(x, ...) {
+as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
   tmp <- tempfile(fileext=".html")
   on.exit(unlink(tmp), add = TRUE)
   htmlwidgets::saveWidget(x, file = tmp, selfcontained = FALSE)
   htmlwidgets:::pandoc_self_contained_html(tmp, tmp)
 
   ## Only in mini, not in the notebook
-  if (!isEditMode()) htmlwidgets.install.ocap()
+  if (ocaps && !isEditMode()) htmlwidgets.install.ocap()
 
   widget <- paste(readLines(tmp), collapse = "\n")
   where <- paste0("rc_htmlwidget_", as.integer(runif(1)*1e6))

--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -226,7 +226,7 @@ as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
 add.iframe.htmlwidget <- function(widget) {
   paste(
     sep = "",
-    "<iframe frameBorder=\"0\" width=\"100%\" height=\"250\" srcdoc=\"",
+    "<iframe frameBorder=\"0\" width=\"100%\" height=\"400\" srcdoc=\"",
     gsub("\"", "&quot;", widget),
     "\"></iframe>"
   )

--- a/rcloud.support/inst/javascript/htmlwidgets.js
+++ b/rcloud.support/inst/javascript/htmlwidgets.js
@@ -7,26 +7,38 @@ function getDocHeight(D) {
     );
 }
 
-function size_this(div) {
+var lastWidths = { };
+
+function size_this(div, reset) {
+    // Check if the widget has a <body> already. If not, we need to wait
+    // a bit
     var D = $(div).find('iframe').contents()[0];
 
     if (!D || !D.body) {
-        setTimeout(function() { size_this($(div)); }, 100);
+        setTimeout(function() { size_this($(div), reset); }, 100);
     } else {
-        var h = getDocHeight(D);
-        $(div).find('iframe').height(h);
-        $(div).find('iframe').attr('height', h);
+        // Check if the width of the iframe is different. If not, then
+        // we don't need to do anything.
+        var rcid = div.id;
+        var width = $(div).find('iframe').width();
+        if (reset || (! rcid in lastWidths) || (lastWidths[rcid] < width)) {
+            var h = getDocHeight(D);
+            $(div).find('iframe').height(h);
+            $(div).find('iframe').attr('height', h);
+        }
+        lastWidths[rcid] = width;
     }
 }
 
-function resize_all() {
+function resize_all(reset) {
     var widgets = $('.rcloud-htmlwidget').find('div');
     $.map(
         widgets,
         function(w) {
-            setTimeout(function() { size_this(w) }, 200)
+            setTimeout(function() { size_this(w, reset) }, 200)
         }
     );
+
     return widgets.length;
 }
 
@@ -42,18 +54,26 @@ function add_hooks() {
 // The resizer is mainly for mini.html, but might be handy for
 // notebook as well, if some widgets resize very slowly.
 
+var lastWidth = window.innerWidth;
+
 $(document).ready(function() {
     add_hooks()
-    function resizer() {
-        var num_widgets = resize_all();
-        if (num_widgets == 0) { setTimeout(resizer, 200); }
+    function resizer(reset) {
+        var num_widgets = resize_all(reset);
+        var interval = 200;
+        if (num_widgets > 0) {
+            setTimeout(resizer, 5000);
+        } else {
+            setTimeout(function() { resizer(true) }, interval);
+        }
     }
-    resizer()
+    resizer(lastWidth < window.innerWidth);
+    lastWidth = window.innerWidth;
 });
 
 function initWidget(div, html, k) {
     $(div).html(html)
-    setTimeout(function() { size_this($(div)); }, 100);
+    setTimeout(function() { size_this($(div), true); }, 100);
     k(null, div);
 }
 

--- a/rcloud.support/inst/javascript/htmlwidgets.js
+++ b/rcloud.support/inst/javascript/htmlwidgets.js
@@ -1,10 +1,20 @@
 
-function getDocHeight(D) {
-    return Math.max(
-        Math.max(D.body.scrollHeight, D.documentElement.scrollHeight),
-        Math.max(D.body.offsetHeight, D.documentElement.offsetHeight),
-        Math.max(D.body.clientHeight, D.documentElement.clientHeight)
-    );
+function getDocHeight(Di) {
+    var D = Di[0];
+
+    if (Di.find('body').css('overflow') === 'hidden') {
+        return Math.max(
+            D.documentElement.offsetHeight,
+            D.documentElement.clientHeight
+        );
+
+    } else {
+        return Math.max(
+            Math.max(D.body.scrollHeight, D.documentElement.scrollHeight),
+            Math.max(D.body.offsetHeight, D.documentElement.offsetHeight),
+            Math.max(D.body.clientHeight, D.documentElement.clientHeight)
+        );
+    }
 }
 
 var lastWidths = { };
@@ -12,7 +22,8 @@ var lastWidths = { };
 function size_this(div, reset) {
     // Check if the widget has a <body> already. If not, we need to wait
     // a bit
-    var D = $(div).find('iframe').contents()[0];
+    var Di = $(div).find('iframe').contents();
+    var D = Di[0];
 
     if (!D || !D.body) {
         setTimeout(function() { size_this($(div), reset); }, 100);
@@ -21,8 +32,8 @@ function size_this(div, reset) {
         // we don't need to do anything.
         var rcid = div.id;
         var width = $(div).find('iframe').width();
-        if (reset || (! rcid in lastWidths) || (lastWidths[rcid] < width)) {
-            var h = getDocHeight(D);
+        if (reset || (! rcid in lastWidths) || (lastWidths[rcid] != width)) {
+            var h = getDocHeight(Di);
             $(div).find('iframe').height(h);
             $(div).find('iframe').attr('height', h);
         }


### PR DESCRIPTION
This adds back the periodic resize checks, but widgets are not getting bigger any more, except if the window or cell is resized to be bigger.

Hopefully solves the problems as much as possible. I have tested it with "good" and "bad" widgets, and also in mini.html.