### PR TITLE
Cancelling from 'new asset' doesn't throw an error

### DIFF
--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -112,9 +112,12 @@ RCloud.UI.scratchpad = (function() {
             }
             $("#new-asset > a").click(function() {
                 // FIXME prompt, yuck. I know, I know.
-                var filename = prompt("Choose a filename for your asset").trim();
+                var filename = prompt("Choose a filename for your asset");
                 if (!filename)
                     return;
+
+                filename = filename.trim();
+
                 if (Notebook.is_part_name(filename)) {
                     alert("Asset names cannot start with 'part[0-9]', sorry!");
                     return;


### PR DESCRIPTION
Because you can't use `trim()` on null.