### PR TITLE
Join cell button hidden for first cell on load

### DIFF
--- a/htdocs/js/ui/cell_commands.js
+++ b/htdocs/js/ui/cell_commands.js
@@ -27,10 +27,13 @@ RCloud.UI.cell_commands = (function() {
                         commands_.map[cmd.key].disable();
                     else
                         commands_.map[cmd.key].enable();
-                    if(!_.every(cmd.display_flags, checkf))
-                        commands_.map[cmd.key].control.hide();
-                    else
-                        commands_.map[cmd.key].control.show();
+
+                    if(cmd.display_flags) {
+                        if(!_.every(cmd.display_flags, checkf))
+                            commands_.map[cmd.key].control.hide();
+                        else
+                            commands_.map[cmd.key].control.show();
+                    }
                 });
             }
         };


### PR DESCRIPTION
The `check_buttons` function correctly shows/hides the 'join' button. This is called when a new cell is added, cell is deleted, cells are rearranged etc.

Code is then run that shows/hides the button based on its display_flags.  These are undefined, so it was then showing the button, regardless.

This show/hide operation is only done if the display_flags are not undefined.