### PR TITLE
images assets are shown correctly in assets

### DIFF
--- a/htdocs/js/notebook/asset_view.js
+++ b/htdocs/js/notebook/asset_view.js
@@ -59,9 +59,6 @@ Notebook.Asset.create_html_view = function(asset_model)
     anchor.click(function() {
         if(!asset_model.active())
             asset_model.controller.select();
-        //ugly fix, but desperate times call for desperate measures.
-        $('#scratchpad-binary object').css('position', 'static')
-                .css('position', 'absolute');
     });
     remove.click(function() {
         asset_model.controller.remove();

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -581,10 +581,6 @@ ul.recent-notebooks-list li a {
     overflow: hidden;
 }
 
-#scratchpad-binary object {
-    position: absolute;
-}
-
 body .modal-dialog.full {
     width: 100%;
     max-height: 100%;


### PR DESCRIPTION
So I've made some changes, and cannot reproduce #1706, or the 'where's my thumb' issue we were seeing on PR #2175,

However, I get the feeling I'm missing something because I see no reason why the `object` element should have a `position: absolute` property/value applied to it. With that in mind, there is no need to switch between `static` and `absolute` in `asset_view.js`.