### PR TITLE
Asset images no longer overlap other panels

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -196,7 +196,8 @@
       <div id="scratchpad-editor-wrapper">
         <div id="scratchpad-editor" class="widget-vsize">
         </div>
-        <div id="scratchpad-binary"></div>
+        <div id="scratchpad-binary">
+        </div>
         <a id="asset-link" target="_blank" href="#">link <i class="icon-share"></i></a>
       </div>
     </div>

--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -204,9 +204,9 @@ RCloud.UI.scratchpad = (function() {
                 // PDF seems not to be supported properly by browsers
                 var sbin = $('#scratchpad-binary');
                 if(/\.pdf$/i.test(this.current_model.filename()))
-                    sbin.html('<p>PDF preview not supported</p>');
+                    sbin.html('<div><p>PDF preview not supported</p></div>');
                 else
-                    sbin.html('<object data="' + this.current_model.asset_url(true) + '"></object>');
+                    sbin.html('<div><object data="' + this.current_model.asset_url(true) + '"></object></div>');
                 sbin.show();
             }
             else {

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -590,6 +590,10 @@ ul.recent-notebooks-list li a {
     width: 100%;
     overflow-x: hidden;
     overflow-y: auto;
+
+    & div {
+        height: 0;
+    }
 }
 
 #scratchpad-binary object {


### PR DESCRIPTION
This seems to fix the Firefox issue of asset panel images overlapping other panels. Tested in Chrome and there is no apparent issue from the changes.