### PR TITLE
htmlwidgets improvements

### DIFF
--- a/htdocs/shared.R
+++ b/htdocs/shared.R
@@ -30,5 +30,5 @@ run <- function(url, query, body, headers) {
   f <- file(fn, "rb")
   r <- readBin(f, raw(), s)
   close(f)
-  list(r, mime::guess_type(base))
+  list(r, mime::guess_type(base), "Cache-Control: max-age=3600")
 }

--- a/htdocs/shared.R
+++ b/htdocs/shared.R
@@ -4,8 +4,18 @@ run <- function(url, query, body, headers) {
   pkg <- pex[1]
   pex <- pex[-1]
   if (any(pex == "..")) stop("invalid component in the path URL")
+
+  ## Try _htmlwidgets/pkg/ first
+  fn <- ""
+  if (pkg %in% c("_htmlwidgets")) {
+    path <- c(substring(pkg, 2), pex[-1])
+    fn <- system.file(package = pex[1], do.call(file.path, as.list(path)))
+  }
+
+  ## Otherwise try pkg/www, and finally the user library
   base <- paste(c("www", pex), collapse="/")
-  if (!nzchar(fn <- system.file(base, package=pkg)) && length(pex) > 1) {
+  if (!nzchar(fn) &&
+      !nzchar(fn <- system.file(base, package=pkg)) && length(pex) > 1) {
       ## try to interpret as user/pkg
       usr <- pkg
       pkg <- pex[1]

--- a/rcloud.support/NAMESPACE
+++ b/rcloud.support/NAMESPACE
@@ -28,6 +28,8 @@ S3method(print, deferred_result)
 export(print.htmlwidget)
 S3method(print, htmlwidget)
 S3method(as.character, htmlwidget)
+export(print.suppress_viewer)
+S3method(print, suppress_viewer)
 
 import(gist)
 import(knitr)

--- a/rcloud.support/NAMESPACE
+++ b/rcloud.support/NAMESPACE
@@ -27,6 +27,7 @@ S3method(print, deferred_result)
 
 export(print.htmlwidget)
 S3method(print, htmlwidget)
+S3method(as.character, htmlwidget)
 
 import(gist)
 import(knitr)

--- a/rcloud.support/NAMESPACE
+++ b/rcloud.support/NAMESPACE
@@ -25,7 +25,8 @@ S3method(rcs.list, RCSff)
 
 S3method(print, deferred_result)
 
-S3method(as.character, htmlwidget)
+export(print.htmlwidget)
+S3method(print, htmlwidget)
 
 import(gist)
 import(knitr)

--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -211,12 +211,6 @@ as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
   )
 }
 
-# you may need this if your widgets insist on spawning in a separate tab
-rcloud.view.recalcitrant.widget <- function(widget) {
-  class(widget) <- setdiff(class(widget), "suppress_viewer")
-  widget
-}
-
 print.htmlwidget <- function(x, ..., view = interactive()) {
 
   where <- paste0("rc_htmlwidget_", as.integer(runif(1)*1e6))
@@ -234,6 +228,8 @@ print.htmlwidget <- function(x, ..., view = interactive()) {
 
   invisible(x)
 }
+
+print.suppress_viewer <- print.htmlwidget
 
 rcloudHTMLDependency <- function(dep) {
 

--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -194,10 +194,7 @@ rcloud.htmlwidgets.viewer <- function(url, height) {
 
   ocaps <- htmlwidgets.install.ocap()
 
-  htmlwidgets:::pandoc_self_contained_html(url, url)
-  widget <- paste(readLines(url), collapse = "\n")
-
-  ocaps$create(where, add.iframe.htmlwidget(widget))
+  ocaps$create(where, add.iframe.htmlwidget(url))
 
   invisible()
 }
@@ -206,24 +203,26 @@ as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
   tmp <- tempfile(fileext=".html")
   on.exit(unlink(tmp), add = TRUE)
   htmlwidgets::saveWidget(x, file = tmp, selfcontained = FALSE)
-  htmlwidgets:::pandoc_self_contained_html(tmp, tmp)
 
   ## Only in mini, not in the notebook
   if (ocaps && !isEditMode()) htmlwidgets.install.ocap()
 
-  widget <- paste(readLines(tmp), collapse = "\n")
   where <- paste0("rc_htmlwidget_", as.integer(runif(1)*1e6))
   res <- paste0(
     "<div class=\"rcloud-htmlwidget\">",
     "<div id=\"", where, "\">",
-    add.iframe.htmlwidget(widget),
+    add.iframe.htmlwidget(tmp),
     "</div>",
     "</div>"
   )
   res
 }
 
-add.iframe.htmlwidget <- function(widget) {
+add.iframe.htmlwidget <- function(url) {
+
+  htmlwidgets:::pandoc_self_contained_html(url, url)
+  widget <- paste(readLines(url), collapse = "\n")
+
   paste(
     sep = "",
     "<iframe frameBorder=\"0\" width=\"100%\" height=\"400\" srcdoc=\"",

--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -183,7 +183,33 @@ htmlwidgets.install.ocap <- function() {
   .htmlwidgets.cache$ocaps
 }
 
-rcloud.htmlwidgets.viewer <- function(url, height) {
+as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
+  TODO
+}
+
+# you may need this if your widgets insist on spawning in a separate tab
+rcloud.view.recalcitrant.widget <- function(widget) {
+  class(widget) <- setdiff(class(widget), "suppress_viewer")
+  widget
+}
+
+print.htmlwidget <- function(x, ..., view = interactive()) {
+
+  html <- htmlwidgets:::toHTML(x, standalone = TRUE)
+  deps <- lapply(htmltools::htmlDependencies(html), rcloudHTMLDependency)
+  rendered <- htmltools::renderTags(html)
+
+  background <- "white"
+  html <- c(
+    "<!DOCTYPE html>", "<html>", "<head>", "<meta charset=\"utf-8\"/>",
+    htmltools::renderDependencies(deps, "href"),
+    rendered$head, "</head>",
+    sprintf(
+      "<body style=\"background-color:%s;\">",
+      htmltools::htmlEscape(background)
+    ),
+    rendered$html, "</body>", "</html>"
+  )
 
   where <- paste0("rc_htmlwidget_", as.integer(runif(1)*1e6))
   rcloud.html.out(paste0(
@@ -194,49 +220,78 @@ rcloud.htmlwidgets.viewer <- function(url, height) {
 
   ocaps <- htmlwidgets.install.ocap()
 
-  ocaps$create(where, add.iframe.htmlwidget(url))
-
-  invisible()
-}
-
-as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
-  tmp <- tempfile(fileext=".html")
-  on.exit(unlink(tmp), add = TRUE)
-  htmlwidgets::saveWidget(x, file = tmp, selfcontained = FALSE)
-
-  ## Only in mini, not in the notebook
-  if (ocaps && !isEditMode()) htmlwidgets.install.ocap()
-
-  where <- paste0("rc_htmlwidget_", as.integer(runif(1)*1e6))
-  res <- paste0(
-    "<div class=\"rcloud-htmlwidget\">",
-    "<div id=\"", where, "\">",
-    add.iframe.htmlwidget(tmp),
-    "</div>",
-    "</div>"
-  )
-  res
-}
-
-add.iframe.htmlwidget <- function(url) {
-
-  htmlwidgets:::pandoc_self_contained_html(url, url)
-  widget <- paste(readLines(url), collapse = "\n")
-
-  paste(
+  widget <- paste(
     sep = "",
     "<iframe frameBorder=\"0\" width=\"100%\" height=\"400\" srcdoc=\"",
-    gsub("\"", "&quot;", widget),
+    gsub("\"", "&quot;", paste(html, collapse = "\n")),
     "\"></iframe>"
   )
+
+  ocaps$create(where, widget)
+
+  invisible(NULL)
 }
 
-isEditMode <- function() {
-  identical(.session$mode, "IDE")
+rcloudHTMLDependency <- function(dep) {
+
+  file <- dep$src$file
+
+  lib <- where_in_path(file, .libPaths())
+  if (is.na(lib)) {
+    warning("Cannot find htmlwidgets dependency: ", file)
+    return(dep)
+  }
+
+  rel_path <- path_inside(file, lib)
+  c_rel_path <- path_components(rel_path)
+  pkg <- c_rel_path[1]
+
+  ## strip off pkg/www or pkg/htmlwidgets
+  pkgpath <- paste(tail(c_rel_path, -2), collapse = "/")
+
+  if (length(c_rel_path) < 2) {
+    warning("Invalid htmlwidgets dependency path: ", file)
+    return(dep)
+  } else if (c_rel_path[2] == "htmlwidgets") {
+    dep$src$href <- paste0("/shared.R/_htmlwidgets/", pkg, "/", pkgpath)
+
+  } else if (c_rel_path[2] == "www") {
+    dep$src$href <- paste0("/shared.R/", pkg, "/", pkgpath)
+  }
+
+  dep
 }
 
-# you may need this if your widgets insist on spawning in a separate tab
-rcloud.view.recalcitrant.widget <- function(widget) {
-  class(widget) <- setdiff(class(widget), "suppress_viewer")
-  widget
+where_in_path <- function(path, parents) {
+  for (parent in parents) {
+    if (is_in_path(path, parent)) return(parent)
+  }
+  NA_character_
+}
+
+is_in_path <- function(path, parent) {
+
+  path <- normalizePath(path)
+  parent <- normalizePath(parent)
+
+  c_path <- path_components(path)
+  c_parent <- path_components(parent)
+
+  if (length(c_path) < length(c_parent)) {
+    FALSE
+
+  } else {
+    all(c_path[seq_along(c_parent)] == c_parent)
+  }
+}
+
+path_components <- function(path) {
+  strsplit(path, "/+")[[1]]
+}
+
+path_inside <- function(path, parent) {
+  c_path <- path_components(path)
+  c_parent <- path_components(parent)
+
+  paste(tail(c_path, -length(c_parent)), collapse = "/")
 }

--- a/rcloud.support/R/htmlwidgets.R
+++ b/rcloud.support/R/htmlwidgets.R
@@ -184,16 +184,6 @@ htmlwidgets.install.ocap <- function() {
 }
 
 as.character.htmlwidget <- function(x, ocaps = TRUE, ...) {
-  TODO
-}
-
-# you may need this if your widgets insist on spawning in a separate tab
-rcloud.view.recalcitrant.widget <- function(widget) {
-  class(widget) <- setdiff(class(widget), "suppress_viewer")
-  widget
-}
-
-print.htmlwidget <- function(x, ..., view = interactive()) {
 
   html <- htmlwidgets:::toHTML(x, standalone = TRUE)
   deps <- lapply(htmltools::htmlDependencies(html), rcloudHTMLDependency)
@@ -211,6 +201,24 @@ print.htmlwidget <- function(x, ..., view = interactive()) {
     rendered$html, "</body>", "</html>"
   )
 
+  if (ocaps) htmlwidgets.install.ocap()
+
+  paste(
+    sep = "",
+    "<iframe frameBorder=\"0\" width=\"100%\" height=\"400\" srcdoc=\"",
+    gsub("\"", "&quot;", paste(html, collapse = "\n")),
+    "\"></iframe>"
+  )
+}
+
+# you may need this if your widgets insist on spawning in a separate tab
+rcloud.view.recalcitrant.widget <- function(widget) {
+  class(widget) <- setdiff(class(widget), "suppress_viewer")
+  widget
+}
+
+print.htmlwidget <- function(x, ..., view = interactive()) {
+
   where <- paste0("rc_htmlwidget_", as.integer(runif(1)*1e6))
   rcloud.html.out(paste0(
     "<div class=\"rcloud-htmlwidget\">",
@@ -218,18 +226,13 @@ print.htmlwidget <- function(x, ..., view = interactive()) {
     "</div>"))
   where <- paste0("#", where)
 
-  ocaps <- htmlwidgets.install.ocap()
+  widget <- as.character(x, ..., ocaps = FALSE)
 
-  widget <- paste(
-    sep = "",
-    "<iframe frameBorder=\"0\" width=\"100%\" height=\"400\" srcdoc=\"",
-    gsub("\"", "&quot;", paste(html, collapse = "\n")),
-    "\"></iframe>"
-  )
+  ocaps <- htmlwidgets.install.ocap()
 
   ocaps$create(where, widget)
 
-  invisible(NULL)
+  invisible(x)
 }
 
 rcloudHTMLDependency <- function(dep) {

--- a/rcloud.support/R/zzz.R
+++ b/rcloud.support/R/zzz.R
@@ -7,6 +7,4 @@
              tryCatch(getNativeSymbolInfo("Rserve_oc_register"),
                       ## we cannot make this an error, because R attempts to try-load the package
                       error=function(e) if (is.null(getOption("rcs.silence.loadcheck"))) warning("WARNING: rcloud.support must be loaded by an Rserve instance, not stand-alone R!")))
-
-  options(viewer = rcloud.htmlwidgets.viewer)
 }

--- a/rcloud.support/inst/javascript/htmlwidgets.js
+++ b/rcloud.support/inst/javascript/htmlwidgets.js
@@ -22,11 +22,16 @@ var lastWidths = { };
 function size_this(div, reset) {
     // Check if the widget has a <body> already. If not, we need to wait
     // a bit
+
     var Di = $(div).find('iframe').contents();
     var D = Di[0];
 
-    if (!D || !D.body) {
-        setTimeout(function() { size_this($(div), reset); }, 100);
+    if (!div.id) {
+        // Do nothing if the div is not there at all
+
+    } else if (!D || !D.body) {
+        setTimeout(function() { size_this(div, reset); }, 100);
+
     } else {
         // Check if the width of the iframe is different. If not, then
         // we don't need to do anything.
@@ -84,6 +89,7 @@ $(document).ready(function() {
 
 function initWidget(div, html, k) {
     $(div).html(html)
+
     setTimeout(function() { size_this($(div), true); }, 100);
     k(null, div);
 }


### PR DESCRIPTION
Addresses #2219.

* We do not use the `viewer` option any more, but define our own `print.htmlwidget` method. This allows more flexible HTML code generation.
* JS "dependencies" are not embedded into the HTML now
* The function that handles widgets with the `suppress_viewer` class is not needed any more. We handle them automatically, by defining a `print.suppress_viewer` method.
* `shared.R` can serve files from `inst/htmlwidgets`. This is how the dependencies are served.
* `shared.R` allows caching for 1 hour.