### PR TITLE
Changing cell language subsequently sets focus to the cell's content

### DIFF
--- a/htdocs/js/ui/cell_commands.js
+++ b/htdocs/js/ui/cell_commands.js
@@ -179,6 +179,7 @@ RCloud.UI.cell_commands = (function() {
                         return that.create_select(languages, function(language) {
                             cell_model.parent_model.controller.change_cell_language(cell_model, language);
                             cell_view.clear_result();
+                            cell_view.edit_source(true);
                         });
                     }
                 },


### PR DESCRIPTION
With a simple call to `cell_view.edit_source(true)`.