### PR TITLE
Asset blur on 'escape'

### DIFF
--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -33,6 +33,18 @@ RCloud.UI.scratchpad = (function() {
                 widget.setOptions({
                     enableBasicAutocompletion: true
                 });
+
+                widget.commands.addCommands([{
+                    name: 'blurCell',
+                    bindKey: {
+                        win: 'Escape',
+                        mac: 'Escape'
+                    },
+                    exec: function() {
+                        that.widget.blur();
+                    }
+                }]);
+
                 session.setMode(new LangMode(false, doc, session));
                 session.setUseWrapMode(true);
                 widget.resize();


### PR DESCRIPTION
Press `esc` whilst focus is on an asset's contents to blur the ACE widget.