### PR TITLE
This prevents the 'revert notebook' shortcut being active for read only notebooks

### DIFF
--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -179,6 +179,7 @@ RCloud.UI.init = function() {
             ]
         },
         on_page: ['edit'],
+        modes: ['writeable'],
         action: function() {
             if(shell.notebook.controller.is_mine() && shell.version()) {
                 editor.revert_notebook(shell.notebook.controller.is_mine(), shell.gistname(), shell.version());


### PR DESCRIPTION
The original issue, #2220, had a good suggestion from @gordonwoodhull about using rcloud extension type flags based 'enabling' of shortcuts.

I have fixed the issue, so 'revert' should not be shown/enabled for read only notebooks, but would prefer to update the code to use a flags based approach, as per the suggestion, in another PR.