### PR TITLE
Firefox autocomplete for search turned off fixes related issues

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -69,7 +69,7 @@
       <i class="icon-search"></i>
       <div class="find">
         <span id="find-details">
-          <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
+          <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find" autocomplete="off"></input>
           <span id="match-status"><span id="match-index"></span> of <span id="match-total"></span></span>
         </span>
         <button id="find-last" class="btn" title="Find Previous"><i class="icon-arrow-left"></i></button>

--- a/htdocs/view.html
+++ b/htdocs/view.html
@@ -45,7 +45,7 @@
           <i class="icon-search"></i>
           <div class="find">
             <span id="find-details">
-              <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
+              <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find" autocomplete="off"></input>
               <span id="match-status"><span id="match-index"></span> of <span id="match-total"></span></span>  
             </span>    
             <button id="find-last" class="btn"><i class="icon-arrow-left"></i></button>


### PR DESCRIPTION
I noticed that on Chrome, the autocomplete for the find field was not showing. Since issues #2213 and #2214 were both specific to Firefox, I have unified the behaviour between the two browsers with this change. Seems to resolve the two issues.