### PR TITLE
Fixes for various find/replace bugs

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -15,10 +15,6 @@ RCloud.UI.find_replace = (function() {
         build_regex(find_input_.val());
         highlight_all();
 
-        // matches_
-        find_match_[matches_.length === 0 ? 'addClass' : 'removeClass']('no-matches');
-        show_match_details(matches_.length === 0 ? '0' : '1', matches_.length);
-
         if(find_input_.val().length) {
             active_match_ = 0;
             show_matches();
@@ -27,9 +23,14 @@ RCloud.UI.find_replace = (function() {
             active_match_ = undefined;
             hide_matches();
         }
+
+        // matches_
+        find_match_[matches_.length === 0 ? 'addClass' : 'removeClass']('no-matches');
+        show_match_details(matches_.length === 0 ? '0' : '1', matches_.length);
     };
 
     function toggle_find_replace(replace) {
+
         if(!find_dialog_) {
 
             var markup = $(_.template(
@@ -63,6 +64,7 @@ RCloud.UI.find_replace = (function() {
             if(navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
                 find_form_.on('focusout', function(e) {
                     setTimeout(function() {
+
                         if($(document.activeElement).closest(find_form_).length === 0) {
                             has_focus_ = false;
                             clear_highlights();
@@ -184,10 +186,7 @@ RCloud.UI.find_replace = (function() {
                     $('#' + cycle[i]).focus();
                     return false;
                 case $.ui.keyCode.ESCAPE:
-                    e.preventDefault();
-                    e.stopPropagation();
                     hide_dialog();
-                    return false;
                 }
                 return undefined;
             });
@@ -232,13 +231,13 @@ RCloud.UI.find_replace = (function() {
                     new_value = find_input_.val();
 
                 if(new_value !== old_value) {
-
                     generate_matches();
-
                     find_input_.data('value', new_value);
                 }
 
             }, 250);
+
+            generate_matches();
 
             build_regex(find_input_.val());
 

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -8,7 +8,7 @@ RCloud.UI.find_replace = (function() {
         find_cycle_ = null, replace_cycle_ = null,
         has_focus_ = false,
         matches_ = [], active_match_,
-        change_interval;
+        change_interval_;
 
     function generate_matches() {
         active_match_ = undefined;


### PR DESCRIPTION
This PR seems to fix issues #2213, #2214, #2215.

- The autocomplete now disappears on Firefox when the dialog closes.
- The change_interval_ was accidentally global, and although its code checked the old/new value in the find field, the matches weren't shown (#2213) when the dialog was shown and the value hadn't changed. (it doesn't change if you close/reopen of course), so `generate_matches` is called manually.