### PR TITLE
Find/replace matches always shown, regardless of current selection

### DIFF
--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -432,6 +432,7 @@ td {
 
 .ace_start.find-highlight {
     position: absolute;
+    z-index: 10;
 }
 
 .inner-tab {


### PR DESCRIPTION
`z-index` change for find match means that the 'match' background will be higher than that of any current selection, and result in the orange (current match) or yellow (match) being shown.