### PR TITLE
solr url config item should be commented

### DIFF
--- a/conf/rcloud.conf.samp
+++ b/conf/rcloud.conf.samp
@@ -11,7 +11,7 @@ github.gist.url: https://gist.github.com/
 #gist.backend: gitgist
 #gist.git.root: ${ROOT}/data/gists
 rcs.engine: redis
-solr.url: http://127.0.0.1:8983/solr/rcloudnotebooks
+#solr.url: http://127.0.0.1:8983/solr/rcloudnotebooks
 rcloud.alluser.addons: rcloud.viewer, rcloud.enviewer, rcloud.notebook.info
 rcloud.languages: rcloud.r, rcloud.python, rcloud.rmarkdown
 compute.separation.modes: IDE


### PR DESCRIPTION
Under the 'Optional Functionality' > 'Search' section of `install.md`, solr installation is inferred as optional.

In that case, `solr.url` should be commented out in the `rcloud.conf.samp` file; otherwise it will cause solr related issues if solr is not installed.