### PR TITLE
fixed NaN current match after replace all, find previous

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -34,7 +34,7 @@ RCloud.UI.find_replace = (function() {
     };
 
     function matches_exist() {
-        return matches_.length !== 0;
+        return matches_.length !== 0 && !isNaN(active_match_);
     }
 
     function toggle_find_replace(replace) {


### PR DESCRIPTION
Fix for issue found by @Prateek032, where NaN is shown for current match after 'replace all' and 'find previous' are clicked.