### PR TITLE
Modifier click + target shortcut support

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -447,7 +447,11 @@
             <td>
               <% _.each(shortcut.keys, function(key_combo, index) { %>
                 <%if(index > 0) {%> / <%}%>
-                <kbd><%=key_combo%></kbd>
+                <%if(_.isObject(key_combo)) { %>
+                  <kbd><%=key_combo.keys%> click</kbd> <span>on the</span> <span class="target"><%=key_combo.target%></span>
+                <% } else { %>
+                  <kbd><%=key_combo%></kbd>
+                <% } %>
               <% }); %>
             </td>
             <td>

--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -135,8 +135,8 @@
 
 <script type="text/html" id="help-snippet">
   <div id="help-wrapper" class="panel-body widget-vsize">
-    <a href="#" id="show-shortcuts" title="Show Keyboard Shortcuts">
-      <i class="icon-keyboard"></i>Keyboard
+    <a href="#" id="show-shortcuts" title="Show Shortcuts">
+      <i class="icon-keyboard"></i>Shortcuts
     </a>
     <div id="help-header">
       <form id="help-form" action="#">
@@ -427,7 +427,7 @@
         <div class="modal-content" style="background-color: rgba(255, 255, 255, 1.0)">
             <div class="modal-header" style="padding-left:20px!important;padding-right:20px!important">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
-                <h4 class="modal-title" style="font-size: 20px">Keyboard shortcuts</h4>
+                <h4 class="modal-title" style="font-size: 20px">Shortcuts</h4>
             </div>
             <div class="modal-body" style="padding-top: 0; max-height:calc(100vh - 120px); overflow-y: auto;">
               <div id="shortcut-content"></div>

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -317,6 +317,12 @@ RCloud.UI.init = function() {
                 ['shift', 'alt', 'enter']
             ]
         },
+        click_keys: {
+            target: 'Play button',
+            win_mac: [
+                ['shift']
+            ]
+        },
         modes: ['writeable']
     }, {
         category: 'Cell Management',

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -317,12 +317,12 @@ RCloud.UI.init = function() {
                 ['shift', 'alt', 'enter']
             ]
         },
-        click_keys: {
-            target: 'Play button',
-            win_mac: [
-                ['shift']
-            ]
-        },
+        // click_keys: {
+        //     target: 'Play button',
+        //     win_mac: [
+        //         ['shift']
+        //     ]
+        // },
         modes: ['writeable']
     }, {
         category: 'Cell Management',

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -46,7 +46,7 @@ RCloud.UI.init = function() {
     RCloud.UI.navbar.init();
     RCloud.UI.selection_bar.init();
 
-    // keyboard shortcuts:
+    // shortcuts:
     RCloud.UI.shortcut_manager.init();
     RCloud.UI.ace_shortcuts.init();
 

--- a/htdocs/js/ui/shortcut_dialog.js
+++ b/htdocs/js/ui/shortcut_dialog.js
@@ -49,7 +49,6 @@ RCloud.UI.shortcut_dialog = (function() {
                         current_shortcut.keys.push(keys.join(' '));
                     });
 
-                    // are there any 'click +' shortcuts?
                     if(shortcut.click_keys) {
                         current_shortcut.keys.push({
                             keys: _.map(shortcut.click_keys.keys, function(key) { return get_key(key); }).join(' '),
@@ -64,7 +63,6 @@ RCloud.UI.shortcut_dialog = (function() {
                 template_data.push(key_group);
             });
 
-            // generate dynamic content:
             var content_template = _.template(
                 $("#shortcut_dialog_content_template").html()
             );

--- a/htdocs/js/ui/shortcut_dialog.js
+++ b/htdocs/js/ui/shortcut_dialog.js
@@ -19,6 +19,15 @@ RCloud.UI.shortcut_dialog = (function() {
                 'General']);
             }
 
+            var get_key = function(key) {
+                var replacement =  _.findWhere([
+                    { initial: 'option', replace_with: 'opt' },
+                    { initial: 'command', replace_with: 'cmd' }
+                ], { initial : key });
+              
+                return replacement ? replacement.replace_with : key;
+            };
+
             _.each(shortcuts_by_category_, function(group) {
 
                 var key_group = {
@@ -29,24 +38,24 @@ RCloud.UI.shortcut_dialog = (function() {
                 _.each(group.shortcuts, function(shortcut) {
 
                     var current_shortcut = {
-                            description : shortcut.description,
-                            keys: []
-                        };
-
+                        description : shortcut.description,
+                        keys: []
+                    };
+ 
                     _.each(shortcut.bind_keys, function(keys) {
-
                         keys = _.map(keys, function(key) { 
-                            
-                            var replacement =  _.findWhere([
-                                { initial: 'option', replace_with: 'opt' },
-                                { initial: 'command', replace_with: 'cmd' }
-                            ], { initial : key });
-                          
-                            return replacement ? replacement.replace_with : key;
+                            return get_key(key);
                         });
-
                         current_shortcut.keys.push(keys.join(' '));
                     });
+
+                    // are there any 'click +' shortcuts?
+                    if(shortcut.click_keys) {
+                        current_shortcut.keys.push({
+                            keys: _.map(shortcut.click_keys.keys, function(key) { return get_key(key); }).join(' '),
+                            target: shortcut.click_keys.target
+                        });
+                    }
 
                     key_group.shortcuts.push(current_shortcut);
 

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -207,8 +207,6 @@ RCloud.UI.shortcut_manager = (function() {
         },
         get_registered_shortcuts_by_category: function(sort_items) {
 
-            //console.log(extension_.sections.all.entries);
-
             var rank = _.map(sort_items, (function(item, index) {
                 return { key: item, value: index + 1 } }));
             rank = _.object(_.pluck(rank, 'key'), _.pluck(rank, 'value'));

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -47,7 +47,8 @@ RCloud.UI.shortcut_manager = (function() {
                 on_page: ['view', 'edit'],
                 ignore_clash: false,
                 enable_in_dialogs: false,
-                enabled: true
+                enabled: true,
+                with_click: false
             });
 
             // clean-up:

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -72,29 +72,32 @@ RCloud.UI.shortcut_manager = (function() {
             }
 
             // if this is a shortcut that needs to be added:
-            if (shortcut.bind_keys && shortcut.bind_keys.length) {
+            if ((shortcut.bind_keys && shortcut.bind_keys.length) || 
+                shortcut.click_keys) {
 
                 shortcut_to_add.key_desc = [];
 
                 // construct the key bindings:
-                for (var i = 0; i < shortcut.bind_keys.length; i++) {
+                if(shortcut.bind_keys) {
+                    for (var i = 0; i < shortcut.bind_keys.length; i++) {
 
-                    // ensure consistent order across definitions:
-                    var bind_keys = _
-                        .chain(shortcut.bind_keys[i])
-                        .map(function(element) {
-                            return element.toLowerCase(); })
-                        .sortBy(function(element) {
-                            var rank = {
-                                "command": 1,
-                                "ctrl": 2,
-                                "shift": 3
-                            };
-                            return rank[element];
-                        }).value();
+                        // ensure consistent order across definitions:
+                        var bind_keys = _
+                            .chain(shortcut.bind_keys[i])
+                            .map(function(element) {
+                                return element.toLowerCase(); })
+                            .sortBy(function(element) {
+                                var rank = {
+                                    "command": 1,
+                                    "ctrl": 2,
+                                    "shift": 3
+                                };
+                                return rank[element];
+                            }).value();
 
-                    // so that they can be compared:
-                    shortcut_to_add.key_desc.push(bind_keys.join('+'));
+                        // so that they can be compared:
+                        shortcut_to_add.key_desc.push(bind_keys.join('+'));
+                    }
                 }
 
                 // with existing shortcuts:

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -47,8 +47,7 @@ RCloud.UI.shortcut_manager = (function() {
                 on_page: ['view', 'edit'],
                 ignore_clash: false,
                 enable_in_dialogs: false,
-                enabled: true,
-                with_click: false
+                enabled: true
             });
 
             // clean-up:
@@ -58,6 +57,15 @@ RCloud.UI.shortcut_manager = (function() {
                 shortcut.bind_keys = shortcut.keys.win_mac;
             } else {
                 shortcut.bind_keys = shortcut.keys[is_mac ? 'mac' : 'win'];
+            }
+
+            // click keys, click on target + keys:
+            if (shortcut.click_keys) {
+                if(shortcut.click_keys.hasOwnProperty('win_mac')) {
+                    shortcut.click_keys.keys = shortcut.click_keys.win_mac;
+                } else {
+                    shortcut.click_keys.keys = shortcut.click_keys[is_mac ? 'mac' : 'win'];
+                }
             }
 
             // if this is a shortcut that needs to be added:

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -53,17 +53,20 @@ RCloud.UI.shortcut_manager = (function() {
             // clean-up:
             var is_mac = ui_utils.is_a_mac();
 
-            if (shortcut.keys.hasOwnProperty('win_mac')) {
-                shortcut.bind_keys = shortcut.keys.win_mac;
-            } else {
-                shortcut.bind_keys = shortcut.keys[is_mac ? 'mac' : 'win'];
+            if(shortcut.keys) {
+                if (shortcut.keys.hasOwnProperty('win_mac')) {
+                    shortcut.bind_keys = shortcut.keys.win_mac;
+                } else {
+                    shortcut.bind_keys = shortcut.keys[is_mac ? 'mac' : 'win'];
+                }
             }
 
             // click keys, click on target + keys:
             if (shortcut.click_keys) {
                 if(shortcut.click_keys.hasOwnProperty('win_mac')) {
                     shortcut.click_keys.keys = shortcut.click_keys.win_mac;
-                } else {
+                } else if(shortcut.click_keys.hasOwnProperty('win') || shortcut.click_keys.hasOwnProperty('mac')) {
+                    // optional for click_keys:
                     shortcut.click_keys.keys = shortcut.click_keys[is_mac ? 'mac' : 'win'];
                 }
             }

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -638,7 +638,7 @@ body .modal-dialog.full {
         float: left;
         margin-right: 20px;
 
-        kbd {
+        kbd, .target, span {
             display: inline-block;
             padding: 3px 5px;
             font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
@@ -650,6 +650,16 @@ body .modal-dialog.full {
             border-bottom-color: #bbb;
             border-radius: 3px;
             box-shadow: inset 0 -1px 0 #bbb;
+        }
+
+        span {
+            background: transparent;
+            border: none;
+            box-shadow: none;
+        }
+
+        .target {
+
         }
 
         table {

--- a/htdocs/view.html
+++ b/htdocs/view.html
@@ -66,7 +66,7 @@
           <div class="modal-content" style="background-color: rgba(255, 255, 255, 1.0)">
               <div class="modal-header" style="padding-left:20px!important;padding-right:20px!important">
                   <button type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
-                  <h4 class="modal-title" style="font-size: 20px">Keyboard shortcuts</h4>
+                  <h4 class="modal-title" style="font-size: 20px">Shortcuts</h4>
               </div>
               <div class="modal-body" style="padding-top: 0; max-height:calc(100vh - 120px); overflow-y: auto;">
                 <div id="shortcut-content"></div>

--- a/htdocs/view.html
+++ b/htdocs/view.html
@@ -86,31 +86,6 @@
                 <td>
                   <% _.each(shortcut.keys, function(key_combo, index) { %>
                     <%if(index > 0) {%> / <%}%>
-                    <kbd><%=key_combo%></kbd>
-                  <% }); %>
-                </td>
-                <td>
-                  <%=shortcut.description%>
-                </td>
-              </tr>
-            <% }); %>
-          </tbody>
-        </table>
-      </div>
-    <% }); %>
-    </script>
-
-    <script type="text/template" id="shortcut_dialog_content_template">
-    <% _.each(categories, function(category) { %>
-      <div class="category">
-        <h3><%=category.name%></h3>
-        <table>
-          <tbody>
-            <% _.each(category.shortcuts, function(shortcut) { %>
-              <tr>
-                <td>
-                  <% _.each(shortcut.keys, function(key_combo, index) { %>
-                    <%if(index > 0) {%> / <%}%>
                     <%if(_.isObject(key_combo)) { %>
                       <kbd><%=key_combo.keys%> click</kbd> <span>on the</span> <span class="target"><%=key_combo.target%></span>
                     <% } else { %>

--- a/htdocs/view.html
+++ b/htdocs/view.html
@@ -100,6 +100,35 @@
     <% }); %>
     </script>
 
+    <script type="text/template" id="shortcut_dialog_content_template">
+    <% _.each(categories, function(category) { %>
+      <div class="category">
+        <h3><%=category.name%></h3>
+        <table>
+          <tbody>
+            <% _.each(category.shortcuts, function(shortcut) { %>
+              <tr>
+                <td>
+                  <% _.each(shortcut.keys, function(key_combo, index) { %>
+                    <%if(index > 0) {%> / <%}%>
+                    <%if(_.isObject(key_combo)) { %>
+                      <kbd><%=key_combo.keys%> click</kbd> <span>on the</span> <span class="target"><%=key_combo.target%></span>
+                    <% } else { %>
+                      <kbd><%=key_combo%></kbd>
+                    <% } %>
+                  <% }); %>
+                </td>
+                <td>
+                  <%=shortcut.description%>
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </div>
+    <% }); %>
+    </script>
+
     <script type="text/javascript"
             src="/mathjax/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>


### PR DESCRIPTION
Intended to be a 'documentation style' shortcut, the new `click_keys` shortcut property enables the following type of shortcut:

'Shift click on the play button'

The object structure is like this:

````javascript
click_keys: {
    target: 'Play button',
    win_mac: [
        ['shift']
    ]
}
````

The `win_mac` property is optional, and follows the pattern of existing shortcuts, which has one of `win`, `mac` or `win_mac` properties set.

I have added an example into `init.js` (see below). 

One aspect I'm not entirely happy with is the display of the shortcut in the shortcut dialog:

![image](https://cloud.githubusercontent.com/assets/2493614/18351456/267dc93a-75d2-11e6-922c-e7ce083add1e.png)

The 'shift' + 'key(s)' and 'target' parts are enclosed in a `kbd` element, but I think this can be better.

This won't be a big change of course.