### PR TITLE
Asset file types handled more effectively

### DIFF
--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -205,7 +205,6 @@ RCloud.UI.scratchpad = (function() {
                 // ArrayBuffer, binary content: display object
                 $('#scratchpad-editor').hide();
 
-                // PDF seems not to be supported properly by browsers
                 var sbin = $('#scratchpad-binary'),
                     extension = this.current_model.filename().substr(this.current_model.filename().lastIndexOf('.') + 1);
 

--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -201,17 +201,18 @@ RCloud.UI.scratchpad = (function() {
             var content = this.current_model.content();
             if (Notebook.is_binary_content(content)) {
                 binary_mode_ = true;
-                
+
                 // ArrayBuffer, binary content: display object
                 $('#scratchpad-editor').hide();
 
                 // PDF seems not to be supported properly by browsers
-                var sbin = $('#scratchpad-binary');
+                var sbin = $('#scratchpad-binary'),
+                    extension = this.current_model.filename().substr(this.current_model.filename().lastIndexOf('.') + 1);
 
-                if(/\.pdf$/i.test(this.current_model.filename())){
-                    sbin.html('<div><p>PDF preview not supported</p></div>');
+                if(['bmp', 'jpg', 'jpeg', 'png', 'gif'].indexOf(extension.toLowerCase()) !== -1) {
+                    sbin.html('<div><img src="' + this.current_model.asset_url(true) + '"/></div>"');
                 } else {
-                    sbin.html('<div><object data="' + this.current_model.asset_url(true) + '"></object></div>');
+                    sbin.html('<div><p>Preview not supported for this file type</p></div>');
                 }
 
                 sbin.show();

--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -201,14 +201,19 @@ RCloud.UI.scratchpad = (function() {
             var content = this.current_model.content();
             if (Notebook.is_binary_content(content)) {
                 binary_mode_ = true;
+                
                 // ArrayBuffer, binary content: display object
                 $('#scratchpad-editor').hide();
+
                 // PDF seems not to be supported properly by browsers
                 var sbin = $('#scratchpad-binary');
-                if(/\.pdf$/i.test(this.current_model.filename()))
+
+                if(/\.pdf$/i.test(this.current_model.filename())){
                     sbin.html('<div><p>PDF preview not supported</p></div>');
-                else
+                } else {
                     sbin.html('<div><object data="' + this.current_model.asset_url(true) + '"></object></div>');
+                }
+
                 sbin.show();
             }
             else {

--- a/htdocs/js/ui/scratchpad.js
+++ b/htdocs/js/ui/scratchpad.js
@@ -211,7 +211,9 @@ RCloud.UI.scratchpad = (function() {
 
                 if(['bmp', 'jpg', 'jpeg', 'png', 'gif'].indexOf(extension.toLowerCase()) !== -1) {
                     sbin.html('<div><img src="' + this.current_model.asset_url(true) + '"/></div>"');
-                } else {
+                } /*else if('pdf' === extension.toLowerCase()) {
+                    sbin.html('<div><object><embed type="application/pdf" src="' + this.current_model.asset_url(true) + '" /></object></div>');
+                }*/ else {
                     sbin.html('<div><p>Preview not supported for this file type</p></div>');
                 }
 


### PR DESCRIPTION
Initially a fix for #2008, this PR removes the catch-all `object` tag and implements `img` tag handling for image types (bmp/jpg/jpeg/png/gif).

[PDF support seems possible](http://plnkr.co/edit/ABmj5Qsh26dkhilZBHsB?p=preview), so I have added some specific code for PDF handling. This can be uncommented when the server returns the appropriate response header.