### PR TITLE
Remove SASS reference

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -135,10 +135,6 @@ be hacking the code, you'll need to install a recent version of
 This will install the node.js dependencies necessary to concatenate and
 minify the JavaScript files used in RCloud.
 
-[SASS](http://sass-lang.com/) is also used to manage the CSS used in RCloud. 
-You can get help installing SASS by heading over to the [installation page]
-(http://sass-lang.com/install) and following the 'command line' instructions.
-
 #### Starting rcloud
 
 The safest way to install rcloud currently is to simply run the


### PR DESCRIPTION
The change from [this comment](https://github.com/att/rcloud/pull/1868#issuecomment-202477028) means that the SASS reference is not required.