### PR TITLE
Find next/previous, replace shortcuts

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -177,7 +177,7 @@ RCloud.UI.find_replace = (function() {
             replace_cycle_.push('find-close');
 
             function find_next_on_keycode(e) {
-                if(e.keyCode===$.ui.keyCode.ENTER || (!ui_utils.is_a_mac() && e.keyCode === 114)) {
+                if(e.keyCode===$.ui.keyCode.ENTER || (!ui_utils.is_a_mac() && e.keyCode === 114 /* f3 */)) {
                     e.preventDefault();
                     e.stopPropagation();
                     if(e.shiftKey)

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -176,7 +176,7 @@ RCloud.UI.find_replace = (function() {
             find_cycle_.push('find-close');
             replace_cycle_.push('find-close');
 
-            function find_next_on_enter(e) {
+            function find_next_on_keycode(e) {
                 if(e.keyCode===$.ui.keyCode.ENTER || (!ui_utils.is_a_mac() && e.keyCode === 114)) {
                     e.preventDefault();
                     e.stopPropagation();
@@ -189,8 +189,8 @@ RCloud.UI.find_replace = (function() {
                 return undefined;
             }
 
-            find_input_.keydown(find_next_on_enter);
-            replace_input_.keydown(find_next_on_enter);
+            find_input_.keydown(find_next_on_keycode);
+            replace_input_.keydown(find_next_on_keycode);
 
             find_form_.keydown(function(e) {
                 switch(e.keyCode) {

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -177,7 +177,7 @@ RCloud.UI.find_replace = (function() {
             replace_cycle_.push('find-close');
 
             function find_next_on_enter(e) {
-                if(e.keyCode===$.ui.keyCode.ENTER) {
+                if(e.keyCode===$.ui.keyCode.ENTER || (!ui_utils.is_a_mac() && e.keyCode === 114)) {
                     e.preventDefault();
                     e.stopPropagation();
                     if(e.shiftKey)
@@ -495,10 +495,6 @@ RCloud.UI.find_replace = (function() {
                         ['shift', 'enter'],
                         ['shift', 'f3']
                     ]
-                },
-                element_scope: '#find-form',
-                action: function() {
-                    find_previous_func_();
                 }
             }, {
                 category: 'Notebook Management',
@@ -512,10 +508,6 @@ RCloud.UI.find_replace = (function() {
                         ['enter'],
                         ['f3']
                     ]
-                },
-                element_scope: '#find-form',
-                action: function() {
-                    find_next_func_();
                 }
             }]);
         },

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -467,8 +467,9 @@ RCloud.UI.find_replace = (function() {
                     ]
                 },
                 modes: ['writeable'],
+                element_scope: '#find-form',
                 action: function() {
-                    console.log('Replace text match');
+                    
                 }
             }]);
         },

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -472,7 +472,7 @@ RCloud.UI.find_replace = (function() {
             }, {
                 category: 'Search/Replace',
                 id: 'notebook_replace_text_match',
-                description: 'Replace text match',
+                description: 'Replace next match',
                 keys: {
                     win_mac: [
                         ['alt', 'r']
@@ -488,7 +488,7 @@ RCloud.UI.find_replace = (function() {
             }, {
                 category: 'Search/Replace',
                 id: 'notebook_replace_text_all',
-                description: 'Replace all',
+                description: 'Replace all matches',
                 keys: {
                     win_mac: [
                         ['alt', 'a']

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -10,7 +10,8 @@ RCloud.UI.find_replace = (function() {
         find_cycle_ = null, replace_cycle_ = null,
         has_focus_ = false,
         matches_ = [], active_match_,
-        change_interval_;
+        change_interval_,
+        replace_shown_ = false;
 
     function generate_matches() {
         active_match_ = undefined;
@@ -40,6 +41,8 @@ RCloud.UI.find_replace = (function() {
     }
 
     function toggle_find_replace(replace) {
+
+        replace_shown_ = replace;
 
         if(!find_dialog_) {
 
@@ -476,7 +479,9 @@ RCloud.UI.find_replace = (function() {
                 modes: ['writeable'],
                 element_scope: '#find-form',
                 action: function() {
-                    replace_next_func_();
+                    if(replace_shown_) {
+                        replace_next_func_();
+                    }
                 }
             }, {
                 category: 'Notebook Management',

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -5,6 +5,7 @@ RCloud.UI.find_replace = (function() {
         find_input_, find_match_, match_index_, match_total_, replace_input_, replace_stuff_,
         find_next_, find_last_, replace_next_, replace_all_, close_,
         replace_next_func_,
+        find_previous_func_, find_next_func_,
         shown_ = false, replace_mode_ = false,
         find_cycle_ = null, replace_cycle_ = null,
         has_focus_ = false,
@@ -476,6 +477,40 @@ RCloud.UI.find_replace = (function() {
                 element_scope: '#find-form',
                 action: function() {
                     replace_next_func_();
+                }
+            }, {
+                category: 'Notebook Management',
+                id: 'notebook_goto_previous_match',
+                description: 'Go to previous search match',
+                keys: {
+                    mac: [
+                        ['shift', 'enter']
+                    ],
+                    win: [
+                        ['shift', 'enter'],
+                        ['shift', 'f3']
+                    ]
+                },
+                element_scope: '#find-form',
+                action: function() {
+
+                }
+            }, {
+                category: 'Notebook Management',
+                id: 'notebook_goto_next_match',
+                description: 'Go to next search match',
+                keys: {
+                    mac: [
+                        ['enter']
+                    ],
+                    win: [
+                        ['enter'],
+                        ['f3']
+                    ]
+                },
+                element_scope: '#find-form',
+                action: function() {
+                    
                 }
             }]);
         },

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -454,6 +454,22 @@ RCloud.UI.find_replace = (function() {
                 },
                 modes: ['writeable'],
                 action: function() { toggle_find_replace(!shell.notebook.model.read_only()); }
+            }, {
+                category: 'Notebook Management',
+                id: 'notebook_replace_text_match',
+                description: 'Replace text match',
+                keys: {
+                    mac: [
+                        ['command', 'r']
+                    ],
+                    win: [
+                        ['ctrl', 'r']
+                    ]
+                },
+                modes: ['writeable'],
+                action: function() {
+                    console.log('Replace text match');
+                }
             }]);
         },
         hide_replace: function() {

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -441,7 +441,7 @@ RCloud.UI.find_replace = (function() {
     var result = {
         init: function() {
             RCloud.UI.shortcut_manager.add([{
-                category: 'Notebook Management',
+                category: 'Search/Replace',
                 id: 'notebook_find',
                 description: 'Find text',
                 keys: {
@@ -456,7 +456,7 @@ RCloud.UI.find_replace = (function() {
                     toggle_find_replace(false);
                 }
             }, {
-                category: 'Notebook Management',
+                category: 'Search/Replace',
                 id: 'notebook_replace',
                 description: 'Replace text',
                 keys: {
@@ -470,7 +470,7 @@ RCloud.UI.find_replace = (function() {
                 modes: ['writeable'],
                 action: function() { toggle_find_replace(!shell.notebook.model.read_only()); }
             }, {
-                category: 'Notebook Management',
+                category: 'Search/Replace',
                 id: 'notebook_replace_text_match',
                 description: 'Replace text match',
                 keys: {
@@ -486,7 +486,7 @@ RCloud.UI.find_replace = (function() {
                     }
                 }
             }, {
-                category: 'Notebook Management',
+                category: 'Search/Replace',
                 id: 'notebook_replace_text_all',
                 description: 'Replace all',
                 keys: {
@@ -502,7 +502,7 @@ RCloud.UI.find_replace = (function() {
                     }
                 }
             }, {
-                category: 'Notebook Management',
+                category: 'Search/Replace',
                 id: 'notebook_goto_previous_match',
                 description: 'Go to previous search match',
                 keys: {
@@ -515,7 +515,7 @@ RCloud.UI.find_replace = (function() {
                     ]
                 }
             }, {
-                category: 'Notebook Management',
+                category: 'Search/Replace',
                 id: 'notebook_goto_next_match',
                 description: 'Go to next search match',
                 keys: {

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -93,7 +93,7 @@ RCloud.UI.find_replace = (function() {
                 });
             }
 
-            function find_next(reason) {
+            find_next_func_ = function(reason) {
                 active_transition(reason || 'deactivate');
 
                 if(matches_exist()) {
@@ -106,7 +106,7 @@ RCloud.UI.find_replace = (function() {
                 active_transition('activate');
             }
 
-            function find_previous() {
+            find_previous_func_ = function() {
                 active_transition('deactivate');
                 
                 if(matches_exist()) {
@@ -122,14 +122,14 @@ RCloud.UI.find_replace = (function() {
             find_next_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();
-                find_next();
+                find_next_func_();
                 return false;
             });
 
             find_last_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();
-                find_previous();
+                find_previous_func_();
                 return false;
             });
 
@@ -139,12 +139,12 @@ RCloud.UI.find_replace = (function() {
                     if(cell) {
                         shell.notebook.controller.update_cell(cell)
                             .then(function() {
-                                find_next('replace');
+                                find_next_func_('replace');
                             });
                     }
                 }
                 else
-                    find_next();
+                    find_next_func_();
 
                 return false;
             };
@@ -178,9 +178,9 @@ RCloud.UI.find_replace = (function() {
                     e.preventDefault();
                     e.stopPropagation();
                     if(e.shiftKey)
-                        find_previous();
+                        find_previous_func_();
                     else
-                        find_next();
+                        find_next_func_();
                     return false;
                 }
                 return undefined;
@@ -493,7 +493,7 @@ RCloud.UI.find_replace = (function() {
                 },
                 element_scope: '#find-form',
                 action: function() {
-
+                    find_previous_func_();
                 }
             }, {
                 category: 'Notebook Management',
@@ -510,7 +510,7 @@ RCloud.UI.find_replace = (function() {
                 },
                 element_scope: '#find-form',
                 action: function() {
-                    
+                    find_next_func_();
                 }
             }]);
         },

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -469,11 +469,8 @@ RCloud.UI.find_replace = (function() {
                 id: 'notebook_replace_text_match',
                 description: 'Replace text match',
                 keys: {
-                    mac: [
-                        ['command', 'r']
-                    ],
-                    win: [
-                        ['ctrl', 'r']
+                    win_mac: [
+                        ['alt', 'r']
                     ]
                 },
                 modes: ['writeable'],

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -4,7 +4,7 @@ RCloud.UI.find_replace = (function() {
         find_form_,
         find_input_, find_match_, match_index_, match_total_, replace_input_, replace_stuff_,
         find_next_, find_last_, replace_next_, replace_all_, close_,
-        replace_next_func_,
+        replace_next_func_, replace_all_func_,
         find_previous_func_, find_next_func_,
         shown_ = false, replace_mode_ = false,
         find_cycle_ = null, replace_cycle_ = null,
@@ -158,15 +158,20 @@ RCloud.UI.find_replace = (function() {
                 replace_next_func_();
             });
 
-            replace_all_.click(function(e) {
-                e.preventDefault();
-                e.stopPropagation();
+            replace_all_func_ = function() {
                 if(matches_exist()) {
                     active_transition('deactivate');
                     replace_rest();
                 }
                 else
                     replace_all(find_input_.val(), replace_input_.val());
+                return false;
+            };
+
+            replace_all_.click(function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                replace_all_func();
                 return false;
             });
 
@@ -478,6 +483,22 @@ RCloud.UI.find_replace = (function() {
                 action: function() {
                     if(replace_shown_) {
                         replace_next_func_();
+                    }
+                }
+            }, {
+                category: 'Notebook Management',
+                id: 'notebook_replace_text_all',
+                description: 'Replace all',
+                keys: {
+                    win_mac: [
+                        ['alt', 'a']
+                    ]
+                },
+                modes: ['writeable'],
+                element_scope: '#find-form',
+                action: function() {
+                    if(replace_shown_) {
+                        replace_all_func_();
                     }
                 }
             }, {

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -4,6 +4,7 @@ RCloud.UI.find_replace = (function() {
         find_form_,
         find_input_, find_match_, match_index_, match_total_, replace_input_, replace_stuff_,
         find_next_, find_last_, replace_next_, replace_all_, close_,
+        replace_next_func_,
         shown_ = false, replace_mode_ = false,
         find_cycle_ = null, replace_cycle_ = null,
         has_focus_ = false,
@@ -131,9 +132,7 @@ RCloud.UI.find_replace = (function() {
                 return false;
             });
 
-            replace_next_.click(function(e) {
-                e.preventDefault();
-                e.stopPropagation();
+            replace_next_func_ = function() {
                 if(matches_exist()) {
                     var cell = replace_current();
                     if(cell) {
@@ -145,7 +144,14 @@ RCloud.UI.find_replace = (function() {
                 }
                 else
                     find_next();
+
                 return false;
+            };
+
+            replace_next_.click(function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                replace_next_func_();
             });
 
             replace_all_.click(function(e) {
@@ -469,7 +475,7 @@ RCloud.UI.find_replace = (function() {
                 modes: ['writeable'],
                 element_scope: '#find-form',
                 action: function() {
-                    
+                    replace_next_func_();
                 }
             }]);
         },

--- a/htdocs/js/ui/shortcut_dialog.js
+++ b/htdocs/js/ui/shortcut_dialog.js
@@ -16,6 +16,7 @@ RCloud.UI.shortcut_dialog = (function() {
                 'Code Prompt',
                 'Cell Management',
                 'Notebook Management',
+                'Search/Replace',
                 'General']);
             }
 

--- a/htdocs/js/ui/shortcut_manager.js
+++ b/htdocs/js/ui/shortcut_manager.js
@@ -129,14 +129,30 @@ RCloud.UI.shortcut_manager = (function() {
                                 var func_to_bind = function(e) {
 
                                     if (is_active(get_by_id(shortcut_to_add.id))) {
-                                        e.preventDefault();
+                                        
+                                        // anything that means the shortcut shouldn't be active?
+                                        var enable = true;
 
-                                        // invoke if conditions are met:
-                                        if ((shortcut.enable_in_dialogs && $('.modal').is(':visible')) ||
-                                            !$('.modal').is(':visible')) {
-                                            shortcut.action(e);
+                                        if(!shortcut.enable_in_dialogs && $('.modal').is(':visible')) {
+                                            enable = false;
                                         }
 
+                                        if(shortcut.element_scope) {
+
+                                            var parent_element = $(shortcut.element_scope);
+                                            var focus_element = $(':focus');
+
+                                            if(parent_element.length && focus_element.length) {
+                                                enable = $.contains(parent_element.get(0), focus_element.get(0));
+                                            } else {
+                                                enable = false;
+                                            }
+                                        }
+
+                                        if(enable) {
+                                            e.preventDefault();
+                                            shortcut.action(e);
+                                        }
                                     }
                                 };
 
@@ -145,7 +161,6 @@ RCloud.UI.shortcut_manager = (function() {
                                 } else {
                                     window.Mousetrap().bind(binding, func_to_bind);
                                 }
-
                             });
                         }
                     }


### PR DESCRIPTION
Try as I might to get mousetrap (shortcut library) to recognise (shift-)f3 inside the search form, but it didn't seem to work.

Therefore, I've piggy-backed onto the existing 'find_next_on_enter' (renamed with 1042c4a) to trap f3/shift f3.

The replace shortcut should only be active within the search form (added `element_scope` with 5d99024).

Find next/previous now documented. Replace shortcut documented.
