### PR TITLE
Firefox search matches on reopen fixed

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -247,10 +247,6 @@ RCloud.UI.find_replace = (function() {
 
             generate_matches();
 
-            build_regex(find_input_.val());
-
-            highlight_all();
-
             find_input_.focus();
 
         } else {


### PR DESCRIPTION
This seems to have resolved issue #2299.