### PR TITLE
Can now paste into find field

### DIFF
--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -61,7 +61,7 @@ RCloud.UI.find_replace = (function() {
             replace_stuff_ = markup.find('.replace');
             close_ = markup.find('#find-close');
 
-            find_input_.on('change paste', function(e) {
+            find_input_.on('change', function(e) {
                 e.preventDefault();
                 e.stopPropagation();
                 generate_matches();


### PR DESCRIPTION
I've tested this on Firefox and Chrome. Pasting is permitted, and the `change` event binding picks up on the pasted change.