### PR TITLE
Cell-based export

### DIFF
--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -287,6 +287,9 @@ Notebook.create_controller = function(model)
         clear_all_selected_cells: function() {
             model.clear_all_selected_cells();
         },
+        get_selected_cells: function() {
+            return model.get_selected_cells();
+        },
         crop_cells: function() {
 
             if(!this.can_crop_cells())

--- a/htdocs/js/notebook/notebook_model.js
+++ b/htdocs/js/notebook/notebook_model.js
@@ -216,6 +216,9 @@ Notebook.create_model = function()
             });
             RCloud.UI.selection_bar.update(this.cells);
         },
+        get_selected_cells: function() {
+            return this.cells.filter(function(cell) { return cell.is_selected(); });
+        },
         crop_cells: function() {
             var that = this, changes = [];
             _.chain(this.cells)

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -183,6 +183,11 @@ RCloud.UI.settings_frame = (function() {
                         RCloud.UI.run_button.reset_on_run(val);
                     }
                 }),
+                'export-only-selected-cells': that.checkbox({
+                    sort: 6000,
+                    default_value: true,
+                    label: "Export only selected cells"
+                }),
                 'addons': that.text_input_vector({
                     sort: 10000,
                     needs_reload: true,

--- a/htdocs/shell_tab.js
+++ b/htdocs/shell_tab.js
@@ -129,6 +129,9 @@ var shell = (function() {
         }, split_cell: function(cell_model, point1, point2) {
             return notebook_controller_.split_cell(cell_model, point1, point2);
         },
+        get_selected_cells: function() {
+            return notebook_controller_.get_selected_cells();
+        },
         load_notebook: function(gistname, version) {
             notebook_controller_.save();
             return do_load(function() {


### PR DESCRIPTION
This adds a setting, 'Export only selected cells'.

Choosing 'Export notebook to file' or 'Export notebook as R Source file' will export only those cells that are selected.

If no cells are selected, I thought it should default to exporting everything. That's somewhat in disagreement to 'Export only selected'; what it means is "if there's something selected, export only that, otherwise, selected everything". Perhaps something a little more pithy is required for the UI though :)