### PR TITLE
Firefox: can click into notebook title and asset names 

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -33,7 +33,7 @@
     <div id="rcloud-navbar-header" class="navbar-header"></div>
     <div class="nav-collapse">
       <ul id="rcloud-navbar-main" class="nav navbar-nav">
-        <li><a href="#"><span id="notebook-author"></span><span id="author-title-dash" style="display:none;">&nbsp;&ndash;&nbsp;</span><span id="rename-notebook" title="Change Title" style="display:none">[<span id="notebook-title"></span>]</a></span><small id="forked-from-desc"></small></li>
+        <li><div><span id="notebook-author"></span><span id="author-title-dash" style="display:none;">&nbsp;&ndash;&nbsp;</span><span id="rename-notebook" title="Change Title" style="display:none">[<span id="notebook-title"></span>]</div></span><small id="forked-from-desc"></small></li>
         <li><a href="#" id="readonly-notebook" style="display:none;">(read-only)</a></li>
         <li><a href="#"><span id="loading"><img id="loading-animation" src="/img/processing.gif" style="height: 20px;width:20px;margin:0"></img></span></a></li>
       </ul>

--- a/htdocs/js/notebook/asset_view.js
+++ b/htdocs/js/notebook/asset_view.js
@@ -1,7 +1,7 @@
 Notebook.Asset.create_html_view = function(asset_model)
 {
     var filename_div = $("<li></li>");
-    var anchor = $("<a href='#'></a>");
+    var tab_content = $("<div></div>");
     var filename_span = $("<span style='cursor:pointer'>" + asset_model.filename() + "</span>");
     var remove = ui_utils.fa_button("icon-remove", "remove", '',
                                     { 'position': 'relative',
@@ -9,14 +9,14 @@ Notebook.Asset.create_html_view = function(asset_model)
                                         'opacity': '0.75'
                                     }, true);
     var thumb_camera = $('<i class="icon-camera" style="padding-left: 4px; cursor: help;" title="Shown as your notebook\'s thumbnail on the Discover page"></i>');
-    anchor.append(filename_span);
-    filename_div.append(anchor);
+    tab_content.append(filename_span);
+    filename_div.append(tab_content);
 
     if(is_thumb(asset_model.filename())) {
-        anchor.append(thumb_camera);
+        tab_content.append(thumb_camera);
     }
 
-    anchor.append(remove);
+    tab_content.append(remove);
     var old_asset_name = filename_span.text();
 
     var rename_file = function(v) {
@@ -74,7 +74,7 @@ Notebook.Asset.create_html_view = function(asset_model)
         select: select,
         validate: function(name) { return editor.validate_name(name); }
     };
-    anchor.click(function() {
+    tab_content.click(function() {
         if(!asset_model.active())
             asset_model.controller.select();
     });
@@ -83,7 +83,7 @@ Notebook.Asset.create_html_view = function(asset_model)
     });
     var result = {
         filename_updated: function() {
-            anchor.text(asset_model.filename());
+            tab_content.text(asset_model.filename());
         },
         content_updated: function() {
             if(asset_model.active())

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -486,7 +486,8 @@ td {
 
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a,
-.nav-tabs > li.active > a {
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > div {
   color: #555555;
   cursor: default;
   background-color: #ffffff;
@@ -500,10 +501,22 @@ td {
 .navbar-nav {
     margin:0;
 }
+
 .navbar-nav>li {
     float:none;
     display:inline-block;
 }
+
+.navbar-nav > li > div {
+    color: #999;
+    display: inline;
+
+    &:hover {
+        color: #fff;
+        cursor: pointer;
+    }    
+}
+
 .navbar-nav>li>a {
     padding-top: 15px;
     padding-bottom: 15px;

--- a/htdocs/sass/rcloud-edit.scss
+++ b/htdocs/sass/rcloud-edit.scss
@@ -1152,16 +1152,38 @@ a.accordion-toggle.right > i {
     display: none;
 }
 
-.nav-tabs > li > a {
+.nav-tabs > li > a,
+.nav-tabs > li > div {
     padding: 5px;
     padding-bottom: 2px;
     color: rgb(28, 66, 87);
     background-color: rgba(224,224,224,0.5);
 }
 
-.nav-tabs > li.active > a {
+.nav-tabs > li > div {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}
+
+.nav-tabs > li > div {
+    display: inline-block;
+    border: 1px solid transparent;
+    border-bottom-color: rgba(224,224,244,0.5);
+}
+
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > div {
     font-weight: bold;
     background-color: rgba(224,224,224,0.75);
+}
+
+.nav-tabs > li.active > div:hover, 
+.nav-tabs > li.active > div:focus {
+    color: #555555;
+    cursor: default;
+    background-color: #ffffff;
+    border: 1px solid #dddddd;
+    border-bottom-color: transparent;
 }
 
 #forked-from-desc {


### PR DESCRIPTION
This fixes #2312, where Firefox would let you click into notebook title and asset names.

Changed the `a` elements to `div`s and updated css.