### PR TITLE
Cannot Pull and Replace Notebook when current notebook is readonly

### DIFF
--- a/htdocs/js/ui/pull_and_replace.js
+++ b/htdocs/js/ui/pull_and_replace.js
@@ -153,12 +153,16 @@ RCloud.UI.pull_and_replace = (function() {
     return {
         init: function() {
             RCloud.UI.advanced_menu.add({
-                 pull_and_replace_notebook: {
+                pull_and_replace_notebook: {
                     sort: 3000,
                     text: "Pull and Replace Notebook",
                     modes: ['edit'],
                     action: function() {
-                        show_dialog();
+                        if(shell.notebook.model.read_only()) {
+                            alert('Sorry, you cannot Pull and Replace into a read only notebook.');
+                        } else {
+                            show_dialog();
+                        }
                     }
                 }
             });


### PR DESCRIPTION
An action point from #2321. My interpretation of 

> disable Pull&Replace when the current notebook is read-only.

Is to recreate how the 'Open in GitHub' menu item works: test, alert, return.