### PR TITLE
Disabled menu items have a noop action

### DIFF
--- a/htdocs/js/ui/advanced_menu.js
+++ b/htdocs/js/ui/advanced_menu.js
@@ -57,6 +57,7 @@ RCloud.UI.advanced_menu = (function() {
                     text: "Publish Notebook",
                     checkbox: true,
                     modes: ['edit'],
+                    disabled_reason: 'You cannot publish this notebook',
                     action: function(value) {
                         function publish_success(gistname, un) {
                             return function(val) {

--- a/htdocs/js/ui/menus.js
+++ b/htdocs/js/ui/menus.js
@@ -58,6 +58,21 @@ RCloud.UI.menu = (function() {
                     var item = extension_.get(menu_item);
                     if(!item || !item.$li)
                         throw new Error('menu disable fail on ' + menu_item);
+
+                    if(!enable) {
+                        item.enabled_action = item.action;
+                        item.action = function() {}    
+                        if(item.disabled_reason) {
+                            item.$li.find('a').attr('title', item.disabled_reason);
+                        }                
+                    } else {
+                        if(item.enabled_action) {
+                            item.action = item.enabled_action;
+                            delete item.enabled_action;
+                        }
+                        item.$li.find('a').removeAttr('title');
+                    }
+
                     item.$li.toggleClass('disabled', !enable);
                     return this;
                 },
@@ -74,7 +89,7 @@ RCloud.UI.menu = (function() {
                     return ret;
                 },
                 create_link: function(item) {
-                    var ret = $.el.li($.el.a({href: '#', id: item.key}, item.text));
+                    var ret = $.el.li($.el.a({href: '#', id: item.key }, item.text));
                     return ret;
                 },
                 create: function(elem) {

--- a/htdocs/js/ui/pull_and_replace.js
+++ b/htdocs/js/ui/pull_and_replace.js
@@ -157,6 +157,7 @@ RCloud.UI.pull_and_replace = (function() {
                     sort: 3000,
                     text: "Pull and Replace Notebook",
                     modes: ['edit'],
+                    disabled_reason: 'You cannot pull and replace into a read only notebook',
                     action: function() {
                         show_dialog();
                     }


### PR DESCRIPTION
The main change has been in the menu code. If an item is disabled the item's function is assigned to a `enabled_action` property, and a noop is assigned to the item's action. On enabling an item, this `enabled_action` property is tested and reassigned to the item's `action` property. If it doesn't exist, then the default `action` is used.

In addition, I thought it would be good UX to inform the user _why_ that item is disabled.

So I added an optional `disabled_reason` property to items (you might want to improve the 'Publish Notebook' item, since it doesn't say _why_). This is then set as the item's `a` title attribute.