### PR TITLE
Fix Solr Async Calls on updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## RCloud 1.8
+
+### Improvements
+* Solr index update calls are non blocking (Requires R 3.3.x)
+
+
 ## RCloud 1.7
 
 In addition to the below changes to RCloud core, this release also supports

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -354,8 +354,7 @@ rcloud.update.notebook <- function(id, content, is.current = TRUE) {
     if (nzConf("solr.url") && is.null(group)) { # don't index private/encrypted notebooks
         star.count <- rcloud.notebook.star.count(id)
         # Curl SSL Bug. Don't fork Curl. Refer http://stackoverflow.com/questions/15466809/libcurl-ssl-error-after-fork
-        #mcparallel(update.solr(res, star.count), detached=TRUE)
-        update.solr(res,star.count)
+        mcparallel(update.solr(res, star.count), detached=TRUE) 
     }
     aug.res
 }

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -353,8 +353,7 @@ rcloud.update.notebook <- function(id, content, is.current = TRUE) {
 
     if (nzConf("solr.url") && is.null(group)) { # don't index private/encrypted notebooks
         star.count <- rcloud.notebook.star.count(id)
-        # Curl SSL Bug. Don't fork Curl. Refer http://stackoverflow.com/questions/15466809/libcurl-ssl-error-after-fork
-        mcparallel(update.solr(res, star.count), detached=TRUE) 
+        update.solr(res, star.count)
     }
     aug.res
 }

--- a/rcloud.support/R/search.R
+++ b/rcloud.support/R/search.R
@@ -15,10 +15,7 @@
   if(!is.null(solr.url)){
     solr.post.url <- httr::parse_url(solr.url)
     solr.post.url$path <- paste(solr.post.url$path,"update?commit=true",sep="/")
-
-    resp <- tryCatch({
-      httr::POST(build_url(solr.post.url) , body=body,add_headers('Content-Type'=content_type), config=httpConfig)   
-    }, error = function(e) {NULL})
+    mcparallel(httr::POST(build_url(solr.post.url) , body=body,add_headers('Content-Type'=content_type), config=httpConfig) ,detach=TRUE)   
   }
 }
 


### PR DESCRIPTION
The latest curl seems to resolve the SSL bug when curl calls are forked