### PR TITLE
verify client version against server version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,10 +7,11 @@ module.exports = function (grunt) {
 
     var config = {
         src: 'src',
+        version: grunt.file.read('VERSION').split('\n')[0],
         pkg: require('./package.json'),
         bundleFiles: [
-            "htdocs/js/rclient.js",
             "htdocs/js/rcloud.js",
+            "htdocs/js/rclient.js",
             "htdocs/js/ui_utils.js",
             "htdocs/js/utils.js",
             "htdocs/js/extension.js",

--- a/htdocs/js/rclient.js
+++ b/htdocs/js/rclient.js
@@ -15,7 +15,7 @@ RClient = {
             // the rcloud ocap-0 performs the login authentication dance
             // success is indicated by the rest of the capabilities being sent
             var session_mode = (opts.mode) ? opts.mode : "client";
-            rserve.ocap([token, execToken], session_mode, function(err, ocaps) {
+            rserve.ocap([token, execToken], session_mode, RCloud.version, function(err, ocaps) {
                 if(err)
                     on_error(err[0], err[1]);
                 else {

--- a/htdocs/js/rcloud.js
+++ b/htdocs/js/rcloud.js
@@ -1,4 +1,6 @@
-RCloud = {};
+RCloud = {
+    version: '<%= conf.version %>'
+};
 
 // FIXME: what is considered an exception - an API error or also cell eval error?
 // We can tell them apart now ...

--- a/rcloud.support/R/ocaps.R
+++ b/rcloud.support/R/ocaps.R
@@ -33,8 +33,9 @@ wrap.all.js.funs <- function(v)
     v
 }
 
-oc.init.authenticate <- function(v, mode="IDE", client.version) {
-    if(client.version != .info$rcloud.info$version.string)
+oc.init.authenticate <- function(v, mode="IDE", client.version=NULL) {
+    if(!is.null(client.version) &&
+       !isTRUE(client.version == .info$rcloud.info$version.string))
       stop(paste('Please do a hard reload with ctrl-F5 (Windows/Linux) or cmd-shift-R (macOS)\nServer version', .info$rcloud.info$version.string, 'does not match client version', client.version))
     .session$mode <- mode
     if (RC.authenticate(v)) {

--- a/rcloud.support/R/ocaps.R
+++ b/rcloud.support/R/ocaps.R
@@ -33,7 +33,9 @@ wrap.all.js.funs <- function(v)
     v
 }
 
-oc.init.authenticate <- function(v, mode="IDE") {
+oc.init.authenticate <- function(v, mode="IDE", client.version) {
+    if(client.version != .info$rcloud.info$version.string)
+      stop(paste('Please do a hard reload with ctrl-F5 (Windows/Linux) or cmd-shift-R (macOS)\nServer version', .info$rcloud.info$version.string, 'does not match client version', client.version))
     .session$mode <- mode
     if (RC.authenticate(v)) {
         ulog("INFO: oc.init.authenticate authenticated user='", .session$user, "', exec.usr='", as.character(.session$exec.usr), "', mode=", mode)


### PR DESCRIPTION
This works, passing to @s-u for review. It just shows a bland Aw, Shucks, but the message should be clear.

I'm not sure if changing the signature of `oc.init.authenticate` is safe.

![image](https://cloud.githubusercontent.com/assets/1366709/23373168/b7e5834e-fcec-11e6-806d-c104d5b82bb1.png)
