### PR TITLE
Use readonly instead of disabled attribute on textarea

### DIFF
--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -319,9 +319,8 @@ ui_utils.set_ace_readonly = function(widget, readonly) {
         highlightGutterLine: !readonly
     });
     widget.renderer.$cursorLayer.element.style.opacity = readonly?0:1;
-    if(readonly) {
-      widget.textInput.getElement().readonly = "readonly";
-    }
+    
+    widget.textInput.setReadOnly(readonly);
 };
 
 ui_utils.twostate_icon = function(item, on_activate, on_deactivate,

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -319,7 +319,9 @@ ui_utils.set_ace_readonly = function(widget, readonly) {
         highlightGutterLine: !readonly
     });
     widget.renderer.$cursorLayer.element.style.opacity = readonly?0:1;
-    widget.textInput.getElement().disabled = readonly;
+    if(readonly) {
+      widget.textInput.getElement().readonly = "readonly";
+    }
 };
 
 ui_utils.twostate_icon = function(item, on_activate, on_deactivate,


### PR DESCRIPTION
The 'disabled' attribute turns off the widget, the 'readonly' however makes it accessible so the text can be selected and copied. 