### PR TITLE
Conf modified to fix script issue

### DIFF
--- a/conf/rcloud.conf.samp
+++ b/conf/rcloud.conf.samp
@@ -15,5 +15,5 @@ rcs.engine: redis
 rcloud.alluser.addons: rcloud.viewer, rcloud.enviewer, rcloud.notebook.info, rcloud.htmlwidgets, rcloud.rmd, rcloud.flexdashboard
 rcloud.languages: rcloud.r, rcloud.python, rcloud.rmarkdown
 compute.separation.modes: IDE
-# if using rcloud-gist-service
+#--: if using rcloud-gist-service
 #rational.githubgist: true


### PR DESCRIPTION
Running fresh_start would cause this issue:

```bash
Loading RCloud configuration file...
Error in read.dcf(rc.cf) : 
  Line starting '# if using rcloud-gi ...' is malformed!
```