### PR TITLE
Make highlighting of filtered options in autocomplete behave more intutitively

### DIFF
--- a/htdocs/lib/js/ace/ext-language_tools.js
+++ b/htdocs/lib/js/ace/ext-language_tools.js
@@ -1081,6 +1081,7 @@ var AcePopup = function(parentNode) {
         }
         return tokens;
     };
+    
     bgTokenizer.$updateOnChange = noop;
     bgTokenizer.start = noop;
 
@@ -1338,8 +1339,12 @@ var Autocomplete = function() {
     };
 
     this.openPopup = function(editor, prefix, keepPopupPosition) {
-        if (!this.popup)
+        if (!this.popup) {
             this.$init();
+            if (editor.session.$mode && editor.session.$mode.$completer && editor.session.$mode.$completer.rowTokenizer) {
+                this.popup.session.bgTokenizer.$tokenizeRow = editor.session.$mode.$completer.rowTokenizer(this.popup);
+            }
+        }
 
         this.popup.setData(this.completions.filtered);
 

--- a/htdocs/lib/js/ace/ext-language_tools.js
+++ b/htdocs/lib/js/ace/ext-language_tools.js
@@ -1269,10 +1269,17 @@ exports.getCompletionPrefix = function (editor) {
     var prefix;
     editor.completers.forEach(function(completer) {
         if (completer.identifierRegexps) {
-            completer.identifierRegexps.forEach(function(identifierRegex) {
+            var prefixExtractor = function(identifierRegex) {
                 if (!prefix && identifierRegex)
                     prefix = this.retrievePrecedingIdentifier(line, pos.column, identifierRegex);
-            }.bind(this));
+            }.bind(this);
+            
+            if(typeof completer.identifierRegexps === "function") {
+                completer.identifierRegexps(editor).forEach(prefixExtractor);
+            } else {
+                completer.identifierRegexps.forEach(prefixExtractor);
+            }
+
         }
     }.bind(this));
     return prefix || this.retrievePrecedingIdentifier(line, pos.column);
@@ -1795,6 +1802,14 @@ var keyWordCompleter = {
         // gw: pass in callback instead of calling it directly, to support asynchronous results
         var completions = session.$mode.getCompletions(state, session, pos, prefix, callback);
         //callback(null, completions);
+    },
+    identifierRegexps: function(editor) {
+      if(editor.session.$mode.$completer) {
+        if(editor.session.$mode.$completer.identifierRegexps) {
+          return editor.session.$mode.$completer.identifierRegexps;
+        }
+      }
+      return [];
     }
 };
 

--- a/htdocs/lib/js/ace/mode-r.js
+++ b/htdocs/lib/js/ace/mode-r.js
@@ -195,6 +195,46 @@ var RCompletions = function() {
       else
          editor.execCommand("insertstring", data.value || data);
    };
+   
+   this.rowTokenizer = function(popup) {
+     return function(row) {
+        var data = popup.data[row];
+        var tokens = [];
+        if (!data)
+            return tokens;
+        if (typeof data == "string")
+            data = {value: data};
+        if (!data.caption)
+            data.caption = data.value || data.name;
+
+        var last = -1;
+        var flag, c;
+        var isFirstMatch = 1;
+        for (var i = 0; i < data.caption.length; i++) {
+            c = data.caption[i];
+            flag = isFirstMatch & (data.matchMask & (1 << i) ? 1 : 0);
+            if (last !== flag) {
+              if(isFirstMatch && last !== -1) {
+                isFirstMatch = 0;
+              }
+              tokens.push({type: data.className || "" + ( flag ? "completion-highlight" : ""), value: c});
+              last = flag;
+            } else {
+                tokens[tokens.length - 1].value += c;
+            }
+        }
+
+        if (data.meta) {
+            var maxW = popup.renderer.$size.scrollerWidth / popup.renderer.layerConfig.characterWidth;
+            var metaData = data.meta;
+            if (metaData.length + data.caption.length > maxW - 2) {
+                metaData = metaData.substr(0, maxW - data.caption.length - 3) + "\u2026";
+            }
+            tokens.push({type: "rightAlignedText", value: metaData});
+        }
+        return tokens;
+    };
+    };
 }).call(RCompletions.prototype);
 
 exports.RCompletions = RCompletions;


### PR DESCRIPTION
**Note** this pull request depends on changes from https://github.com/att/rcloud/pull/2430

ACE performs filtering of autocomplete options based on user's input by performing sort of position-based character search. The information acquired during filtering phase (which characters 'matched' and their score) are then used to display the options in the UI and highlight parts of an option which were identified as 'matching' the filtering criteria.  

This leads to the following behavior though:
For an input: '"/tmp/' + [TAB or CTRL+SPACE] + 'sth'
User will see (e.g.): ('*' - text between these is highlighted)
`
*/tmp/s*ome-pa*th*
`
`
 */tmp/*thi*s*-is-some-o*th*er-path
`

Although this can be intuitive for natural language completions, it isn't for file-system paths (which might have random characters) and tokens from programming languages. (Plus it seems that ACE's 
 filtering algorithm produces false positives)

This change makes sure that ACE just highlights the base continuous sequence of characters that matched the filtering criteria. E.g: (for the input from the above example)
`
*/tmp/s*ome-path
`
`
 */tmp/*this-is-some-other-path
`

