### PR TITLE
Introduce can_write method on notebook controller, FIX #2437

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -1571,9 +1571,9 @@ var editor = function () {
         },
         fork_folder: function(node, match, replace) {
             var that = this;
-            var is_mine = node.user === that.username();
             var promises = [];
             editor.for_each_notebook(node, null, function(node) {
+                var is_mine = node.user === that.username();
                 promises.push(shell.fork_and_name_notebook(is_mine, node.gistname, null, false, function(desc) {
                     return Promise.resolve(desc.replace(match, replace));
                 }).then(function(notebook) {
@@ -1601,8 +1601,8 @@ var editor = function () {
                 }
             });
         },
-        revert_notebook: function(is_mine, gistname, version) {
-            if(!is_mine)
+        revert_notebook: function(can_edit, gistname, version) {
+            if(!can_edit)
                 return Promise.reject(new Error("attempted to revert notebook not mine"));
             if(!version)
                 return Promise.reject(new Error("attempted to revert current version"));

--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -572,7 +572,11 @@ Notebook.create_controller = function(model)
         //////////////////////////////////////////////////////////////////////
 
         is_mine: function() {
-            return rcloud.username() === model.user() || is_collaborator(this.current_gist(), rcloud.username());
+            return rcloud.username() === model.user();
+        },
+        
+        can_write: function() {
+            return this.is_mine() || is_collaborator(this.current_gist(), rcloud.username());
         },
 
         //////////////////////////////////////////////////////////////////////

--- a/htdocs/js/ui/configure_readonly.js
+++ b/htdocs/js/ui/configure_readonly.js
@@ -5,7 +5,7 @@ RCloud.UI.configure_readonly = function() {
     var readonly_notebook = $("#readonly-notebook");
     var revertb = RCloud.UI.navbar.control('revert_notebook'),
         saveb = RCloud.UI.navbar.control('save_notebook');
-    if(shell.notebook.controller.is_mine()) {
+    if(shell.notebook.controller.can_write()) {
         if(shell.notebook.model.read_only()) {
             revertb && revertb.show();
             saveb && saveb.hide();

--- a/htdocs/js/ui/init.js
+++ b/htdocs/js/ui/init.js
@@ -181,11 +181,11 @@ RCloud.UI.init = function() {
         },
         on_page: ['edit'],
         is_active: function() {
-            return shell.notebook.controller.is_mine() && shell.notebook.model.read_only();
+            return shell.notebook.controller.can_write() && shell.notebook.model.read_only();
         },
         action: function() {
             if(this.is_active()) {
-                editor.revert_notebook(shell.notebook.controller.is_mine(), shell.gistname(), shell.version());
+                editor.revert_notebook(shell.notebook.controller.can_write(), shell.gistname(), shell.version());
             }
         }
     }, {

--- a/htdocs/js/ui/navbar.js
+++ b/htdocs/js/ui/navbar.js
@@ -203,10 +203,10 @@ RCloud.UI.navbar = (function() {
                     create: function() {
                         var control = RCloud.UI.navbar.create_button('revert-notebook', 'Revert', 'icon-undo');
                         $(control.control).click(function() {
-                            var is_mine = shell.notebook.controller.is_mine();
+                            var can_write = shell.notebook.controller.can_write();
                             var gistname = shell.gistname();
                             var version = shell.version();
-                            editor.revert_notebook(is_mine, gistname, version);
+                            editor.revert_notebook(can_write, gistname, version);
                         });
                         return control;
                     }


### PR DESCRIPTION
Introduced the can_write method on notebook.controller which indicates if user can edit a given notebook. Made other components use it if applicable. The is_mine method is still used, as the fork functionality applies different forking method if the fork is performed by the owner.

I also modified the fork_folder method so it doesn't assume that all notebooks in the folder are owned by the user - this comes from my guess that in case of collaborators the implication may not be valid any more. But if this isn't true, I will revert that change.