### PR TITLE
Add match case and match word options to find functionality, Fix #2425

### DIFF
--- a/htdocs/edit.html
+++ b/htdocs/edit.html
@@ -69,14 +69,21 @@
       <i class="icon-search"></i>
       <div class="find">
         <span id="find-details">
-          <input type=text id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
-          <span id="match-status"><span id="match-index"></span> of <span id="match-total"></span></span>
+          <input type="text" id="find-input" class="form-control-ext mousetrap" placeholder="Find"></input>
+          <span id="match-status"><span id="match-index"/> of <span id="match-total"/></span>
+        </span>
+        <span class="btn-group" id="find-options-menu">
+            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown"><i class="icon-ellipsis-horizontal"></i></button>
+            <ul class="dropdown-menu">
+              <li><span class="checkbox"><label><input type="checkbox" id="match-case-opt"/>Match case</label></span></li>
+              <li><span class="checkbox"><label><input type="checkbox" id="match-word-opt"/>Match word</label></span></li>
+            </ul>
         </span>
         <button id="find-last" class="btn" title="Find Previous"><i class="icon-arrow-left"></i></button>
         <button id="find-next" class="btn btn-primary" title="Find Next"><i class="icon-arrow-right"></i></button>
       </div>
       <div class="replace" style="display:none">
-        <input type=text id="replace-input" class="form-control-ext mousetrap" placeholder="Replace"></input>
+        <input type="text" id="replace-input" class="form-control-ext mousetrap" placeholder="Replace"></input>
         <button id="replace" class="btn">Replace</button>
         <button id="replace-all" class="btn">Replace All</button>
       </div>

--- a/htdocs/js/ui/find_replace.js
+++ b/htdocs/js/ui/find_replace.js
@@ -59,6 +59,23 @@ RCloud.UI.find_replace = (function() {
             replace_stuff_ = markup.find('.replace');
             close_ = markup.find('#find-close');
 
+            var close_bootstrap_dropdowns = function(e) {
+                var dropdowns = $('.dropdown-menu');
+                dropdowns.each(function(i, x) {
+                  if($(x).is(":visible")) {
+                    $(x.parentElement).find(".dropdown-toggle").dropdown('toggle');
+                  }
+                });
+            };
+            
+            var toggle_highlight_details_menu_button = function(option) {
+                if(option.get(0).checked) {
+                  $('#find-options-menu > .btn').addClass('active');
+                } else {
+                  $('#find-options-menu > .btn').removeClass('active');
+                }
+            };
+            
             find_input_.on('change', function(e) {
                 e.preventDefault();
                 e.stopPropagation();
@@ -67,10 +84,10 @@ RCloud.UI.find_replace = (function() {
             find_options_menu_.on('hide.bs.dropdown', function (e) {
                 var target = $(e.target);
                 var keepOpenElements = target.find("[data-keepOpen='true']");
-                if(keepOpenElements.length){
+                if (keepOpenElements.length) {
                     keepOpenElements.each(function(i, x) { $(x).attr("data-keepOpen", false); });
                     return false;
-                }else{
+                } else {
                     return true;
                 }
             });
@@ -80,15 +97,20 @@ RCloud.UI.find_replace = (function() {
             });
             
             match_case_opt_.on('change', function(e) {
+                toggle_highlight_details_menu_button(match_case_opt_);
                 generate_matches();
             });
             
             match_word_opt_.on('change', function(e) {
+                toggle_highlight_details_menu_button(match_word_opt_);
                 generate_matches();
             });
 
             find_details_.click(function() { find_input_.focus(); });
-            find_input_.click(function(e) { e.stopPropagation(); }); // click cursor
+            find_input_.click(function(e) { 
+              e.stopPropagation(); 
+              close_bootstrap_dropdowns();
+            }); // click cursor
 
             // disabling clear results on blur for firefox, since its implementation
             // is either the only unbroken one or the only broken one (unclear)
@@ -119,6 +141,7 @@ RCloud.UI.find_replace = (function() {
             find_next_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();
+                close_bootstrap_dropdowns();
                 find_next();
                 return false;
             });
@@ -126,6 +149,7 @@ RCloud.UI.find_replace = (function() {
             find_last_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();
+                close_bootstrap_dropdowns();
                 find_previous();
                 return false;
             });
@@ -133,12 +157,14 @@ RCloud.UI.find_replace = (function() {
             replace_next_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();
+                close_bootstrap_dropdowns();
                 replace_next();
             });
 
             replace_all_.click(function(e) {
                 e.preventDefault();
                 e.stopPropagation();
+                close_bootstrap_dropdowns();
                 replace_all();
                 return false;
             });
@@ -372,8 +398,7 @@ RCloud.UI.find_replace = (function() {
         var filter = escapeRegExp(findOpts.filter);
         regex_group = 0;
         if(findOpts.matchWord) {
-          var nonWord = "[^\\.\\w]";
-          filter = nonWord + "(" + filter + ")" + nonWord;
+          filter = "\\b(" + filter + ")\\b";
           regex_group = 1;
         }
         regex_ = new RegExp(filter, modifiers);

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -340,7 +340,7 @@ td {
         vertical-align: middle;
     }
 
-    input {
+    input[ type = "text"] {
         width: 160px;
         padding-right: 4px;
         background-color: white!important;
@@ -352,6 +352,12 @@ td {
                 -webkit-box-shadow: 0 0 0px 1000px #fff inset;
             }
         }
+    }
+    
+    .checkbox {
+      margin-bottom: 1px;
+      margin-top: 1px;
+      margin-left: 5px;
     }
 
     #find-input {

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -354,6 +354,12 @@ td {
         }
     }
     
+    #find-options-menu {
+      .btn.active {
+        background-color: orange;
+      }
+    }
+    
     .checkbox {
       margin-bottom: 1px;
       margin-top: 1px;


### PR DESCRIPTION
Added drop-down menu to find toolbar (next to the text input) which lets the user specify match case and match word options. 

If 'match word' option is selected the 'dot' character is treated as regular word character.

Cheers
