### PR TITLE
Use DT to render variables in dataframe viewer

### DIFF
--- a/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
+++ b/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
@@ -2,12 +2,42 @@ rcloud.enviewer.refresh <- function()
   rcloud.enviewer.on.change(.GlobalEnv)
 
 ## OCAP
-rcloud.enviewer.view.dataframe <- function(expr)
-  View(get(expr, .GlobalEnv))
+rcloud.enviewer.view.dataframe <- function(expr) {
+  # pass un-evaluated expression, so it can be used by View
+  View(get(expr, .GlobalEnv), expr = expr)
+}
+
+#'
+#' @param name data.frame variable name
+#' @param options dataTables request parameters
+#' @return datatables JS result object (see datatables documentation)
+rcloud.enviewer.view.dataframe.page <- function(name, options) {
+  val <- get(name, .GlobalEnv)
+  
+  result <- list(draw = options$draw)
+  
+  if(is.data.frame(val)) {
+    records <- nrow(val)
+    result$recordsTotal <- records
+    result$recordsFiltered <- records 
+    page <- seq(options$start,min(options$start+options$length, records))
+    data <- tryCatch(jsonlite::toJSON(cbind(as.integer(rownames(val)[page]),val[page,]), dataframe = "values"))
+    if(typeof(data) == "try-error") {
+      result$error <- paste0("Could not marshal data.frame data. Error: ", as.character(data))
+    } else {
+      result$data <- data
+    }
+    return(result)
+  } else {
+    result$error <- paste0("Unsupported variable type: ", typeof(val))
+  }
+  return(result)
+}
 
 ## -- how to handle each group --
-rcloud.enviewer.display.dataframe <- function(x, val)
+rcloud.enviewer.display.dataframe <- function(x, val) {
   structure(list(command="view", object=x, text=paste0("data.frame [",paste(dim(val), collapse=', '),"]")), class="data")
+}
 
 rcloud.enviewer.display.value <- function(val) {
     type <- class(val)

--- a/rcloud.packages/rcloud.enviewer/R/zzz.R
+++ b/rcloud.packages/rcloud.enviewer/R/zzz.R
@@ -11,7 +11,8 @@ rcloud.enviewer.caps <- NULL
   rcloud.enviewer.caps <<- f("rcloud.enviewer", "rcloud.enviewer.js")
   if(!is.null(rcloud.enviewer.caps)) {
     ocaps <- list(refresh = rcloud.support:::make.oc(rcloud.enviewer.refresh),
-                  view_dataframe = rcloud.support:::make.oc(rcloud.enviewer.view.dataframe))
+                  view_dataframe = rcloud.support:::make.oc(rcloud.enviewer.view.dataframe),
+                  view_dataframe_page = rcloud.support:::make.oc(rcloud.enviewer.view.dataframe.page))
     rcloud.enviewer.caps$init(ocaps)
   }
 }

--- a/rcloud.packages/rcloud.viewer/DESCRIPTION
+++ b/rcloud.packages/rcloud.viewer/DESCRIPTION
@@ -5,5 +5,6 @@ Author: Gordon Woodhull <gordon@research.att.com>
 Maintainer: Gordon Woodhull <gordon@research.att.com>
 Description: rcloud.viewer implements View by putting a table into an RCloud side panel
 Depends: rcloud.support
+Suggests: DT
 NOTE: --- packages that are not on CRAN/RForge.net *must* be in Suggests! ---
 License: MIT

--- a/rcloud.packages/rcloud.viewer/DESCRIPTION
+++ b/rcloud.packages/rcloud.viewer/DESCRIPTION
@@ -5,6 +5,6 @@ Author: Gordon Woodhull <gordon@research.att.com>
 Maintainer: Gordon Woodhull <gordon@research.att.com>
 Description: rcloud.viewer implements View by putting a table into an RCloud side panel
 Depends: rcloud.support
-Suggests: DT
+Suggests: DT, rcloud.htmlwidgets
 NOTE: --- packages that are not on CRAN/RForge.net *must* be in Suggests! ---
 License: MIT

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -27,8 +27,11 @@ View <- function (x, title, expr)
     title <- paste("Data:", varName)
   
   if(!requireNamespace("DT", quietly = TRUE)) {
-    x <- paste0('<div class="error-message"><span>DT package is not available, dataframe viewer functionality is not available</span></div>')
+    x <- paste0('<div class="error-message"><span>DT package is not installed, dataframe viewer functionality is not available</span></div>')
+  } else if(!requireNamespace("rcloud.htmlwidgets", quietly = TRUE)) {
+    x <- paste0('<div class="error-message"><span>rcloud.htmlwidgets package is not installed, dataframe viewer functionality is not available</span></div>')
   } else {
+    require(rcloud.htmlwidgets)
     require(DT)
     x <- renderDataFrame(varName, x, title)
   }

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -1,33 +1,85 @@
 # there doesn't seem to be a lower-level way to customize View?
 
+ENVIEWER_PAGE_SIZE <- 20
 
-View <- function (x, title)
+defaultEnviewerDTOptions <- function() {
+  options <- list()
+  options$paging <- TRUE
+  options$pagingType <- "full"
+  options$lengthChange <- FALSE
+  options$searching <- FALSE
+  options$info <- FALSE
+  options$ordering <- FALSE
+  options$pageLength <- ENVIEWER_PAGE_SIZE
+  invisible(options)
+}
+
+View <- function (x, title, expr)
 {
   # borrow pre-processing from base R, replace the final command
-  if (missing(title))
-    title <- paste("Data:", deparse(substitute(x))[1])
-  as.num.or.char <- function(x) {
-    if (is.character(x))
-      x
-    else if (is.numeric(x)) {
-      storage.mode(x) <- "double"
-      x
-    }
-    else as.character(x)
+  
+  if(!missing(expr)) {
+    varName <- expr
+  } else {
+    varName <- deparse(substitute(x))[1]
   }
-  x0 <- as.data.frame(x)
-  x <- lapply(x0, as.num.or.char)
-  rn <- row.names(x0)
-  if (any(rn != seq_along(rn)))
-    x <- c(list(row.names = rn), x)
-  if (!is.list(x) || !length(x) || !all(sapply(x, is.atomic)) ||
-      !max(sapply(x, length)))
-    stop("invalid 'x' argument")
-  x <- as.data.frame(x)
-  if(nrow(x) > 1000)
-    x <- x[1:1000,]
-
+  if (missing(title))
+    title <- paste("Data:", varName)
+  
+  if(!requireNamespace("DT", quietly = TRUE)) {
+    x <- paste0('<div class="error-message"><span>DT package is not available, dataframe viewer functionality is not available</span></div>')
+  } else {
+    require(DT)
+    x <- renderDataFrame(varName, x, title)
+  }
   # R calls invisible(.External2(C_dataviewer, x, title)) here
   invisible(rcloud.viewer.caps$view(x, title))
 }
 
+#' Returns HTML representation of given variable
+#' If varValue is a data.frame it renders DT widget which delegates paging to the server.
+#' If the varValue is of other type than data.frame, it is converted to data.frame and rendereed as 'static' DT (i.e. all variable data is sent to client) 
+#' 
+renderDataFrame <- function(varName, varValue, title) {
+  if(is.data.frame(varValue)) {
+    if(nrow(varValue) > 0 && ncol(varValue) > 0) {
+      options <- defaultEnviewerDTOptions()
+      options$serverSide <- TRUE
+      options$paging <- (nrow(varValue) > ENVIEWER_PAGE_SIZE)
+      # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
+      options$ajax <- JS(paste0('function(data, callback, settings) {
+    if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.enviewer) {
+        window.parent.RCloud.UI.enviewer.dataFrameCallback("', varName, '", data, callback, settings);
+    }
+    }'))
+      data <- data.frame(matrix(ncol = ncol(varValue), nrow = 0))
+      names(data) <- names(varValue)
+      x <- as.character(DT::datatable(data, caption = title, options = options, style = 'default', width = "100%"))
+    } else {
+      x <- paste0('<div><span>Data frame "', varName, '" is empty.</span></div>')
+    }
+  } else {
+    as.num.or.char <- function(x) {
+      if (is.character(x))
+        x
+      else if (is.numeric(x)) {
+        storage.mode(x) <- "double"
+        x
+      }
+      else as.character(x)
+    }
+    x0 <- as.data.frame(varValue)
+    x <- lapply(x0, as.num.or.char)
+    rn <- row.names(x0)
+    if (any(rn != seq_along(rn)))
+      x <- c(list(row.names = rn), x)
+    if (!is.list(x) || !length(x) || !all(sapply(x, is.atomic)) ||
+        !max(sapply(x, length)))
+      stop("invalid 'varValue' argument")
+    x <- as.data.frame(x)
+    options <- defaultEnviewerDTOptions()
+    options$paging <- (nrow(x) > ENVIEWER_PAGE_SIZE)
+    x <- as.character(datatable(x, caption = title, options = options, style = 'default', width = 400))
+  }
+  invisible(x)
+}

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -28,33 +28,8 @@ return {
         k();
     },
     view: function(data, title, k) {
-        $('#viewer-body > table').remove();
-        var columns = data.r_attributes.names;
-        if(typeof columns === 'string')
-            columns = [columns];
-        columns = _.without(columns, 'r_attributes', 'r_type');
-        if(columns.length<1)
-            k();
-        var nrows = data[columns[0]].length;
-        if(nrows>1000) nrows = 1000;
-        // styling the table would go better with CSS but we can only
-        // install CSS by URL right now(?)
-        var header_style = 'border: 0; background-color: #dedede; font-family: sans-serif; font-size: 12px; text-align: right; white-space: nowrap';
-        var datum_style = 'border-style: solid; border-width: thin 0; border-color: #aaa; text-align: right; padding-left: 10px; white-space: nowrap';
-        var header = $.el.tr({}, [$.el.th({style: 'border: none'})].concat(columns.map(function(x) {
-            return $.el.th({scope:'col', style: header_style}, x);
-        })));
-        var rows = [header];
-        for(var i = 0; i<nrows; ++i) {
-            function fetch(col) {
-                return $.el.td({style: datum_style}, data[col][i]);
-            }
-            var items = [$.el.th({scope: 'row', style: header_style}, i)].concat(columns.map(fetch));;
-            rows.push($.el.tr({}, items));
-        }
-        $('#viewer-body').append($.el.table({style: "border-collapse: collapse; max-width: none"}, rows));
-        $('#viewer-body tr:first-child + tr td').css({'border-top': 0});
-        $('#viewer-body tr:first-child th').css({'padding-left': '10px'});
+        $('#viewer-body > div').remove();
+        $('#viewer-body').append($(data));
         RCloud.UI.right_panel.collapse($("#collapse-data-viewer"), false, false);
         k();
     }


### PR DESCRIPTION
With this change DT (JS datatables) will be used to display variable values in dataframe viewer.
If a variable has data.frame type a pageable datatable will be rendered which only will send requested page to client.
If a variable doesn't have data.frame type a pageable datatable will be rendered, but all data will be sent to client.
    FIX #2427 

To achieve as simple and clear data viewer as possible I turned off some of the features that are enabled by default in DT: page size select box, search text input and I also used simple page navigation instead of the default that lists first, last and neighboring page numbers. Alternative to turning these features off would be to modify CSS so the viewer is more compact.

BTW The server-side processing feature of DT used in this solution could also be exposed in flex.dashboard/RCAP/view modes allowing for displaying large data frames.