### PR TITLE
Open notebook in view mode when alt-clicked from recent notebooks…

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -450,7 +450,12 @@ var editor = function () {
                 e.preventDefault();
                 var gist = $(e.currentTarget).data('gist');
                 $('.dropdown-toggle.recent-btn').dropdown("toggle");
-                result.open_notebook(gist, undefined, undefined, undefined, e.metaKey || e.ctrlKey);
+                if(e.altKey) {
+                  var url = ui_utils.make_url('view.html', {notebook: gist});
+                  window.open(url, "_blank");
+                } else {
+                  result.open_notebook(gist, undefined, undefined, undefined, e.metaKey || e.ctrlKey);
+                }
             };
             var create_recent_link = function(notebook) {
                 var li = $('<li></li>');


### PR DESCRIPTION
FIX #2424

I had to do some tweaking of ubuntu desktop settings to test this one, as by default ubuntu is capturing alt-clicks (It triggers window drag and move functionality).

But this raises a question if we should consider changing the alteration key to something else than <kbd>alt click</kbd>, as this might be a common problem for ubuntu users?