### PR TITLE
Make sure that drop-down menus are displayed on top of panel resize slider

### DIFF
--- a/htdocs/sass/rcloud-edit.scss
+++ b/htdocs/sass/rcloud-edit.scss
@@ -1122,7 +1122,7 @@ a.accordion-toggle.right > i {
 
 .notebook-sizer {
     position:absolute;
-    z-index: 10000;
+    z-index: 999;
     cursor: ew-resize;
     bottom: 0;
     opacity: 0;


### PR DESCRIPTION
FIX #2463

I decreased z-index for resize slider to be below 1000 (bootstrap drop-down z-index default). Modifying bootstrap's default z-index  from drop-down class to something above 10000 was not correctly picked up by Shareable link and Advanced menu drop down menus.