### PR TITLE
Check if solr feature is enabled where needed. FIX #2479

### DIFF
--- a/rcloud.support/R/notebook.comments.R
+++ b/rcloud.support/R/notebook.comments.R
@@ -11,7 +11,7 @@ rcloud.post.comment <- function(id, content)
 {
   res <- create.gist.comment(id, content, ctx = .rcloud.get.gist.context())
   rcloud.comments.email(id, content, ' posted a new')
-  if (nzConf("solr.url")) mcparallel(rcloud.solr::solr.post.comment(id, content, res$content$id), detached=TRUE)
+  if (is.rcloud.solr.feature.enabled()) mcparallel(rcloud.solr::solr.post.comment(id, content, res$content$id), detached=TRUE)
   res
 }
 
@@ -19,13 +19,17 @@ rcloud.modify.comment <- function(id, cid, content)
 {
   res <- modify.gist.comment(id,cid,content, ctx = .rcloud.get.gist.context())
   rcloud.comments.email(id, content, ' modified an old')
-  mcparallel(rcloud.solr::solr.modify.comment(id, content, cid), detached=TRUE)
+  if(is.rcloud.solr.feature.enabled()) {
+    mcparallel(rcloud.solr::solr.modify.comment(id, content, cid), detached=TRUE)
+  }
   res$ok
 }
 
 rcloud.delete.comment <- function(id,cid)
 {
-  mcparallel(rcloud.solr::solr.delete.comment(id, cid), detached=TRUE)
+  if(is.rcloud.solr.feature.enabled()) {
+    mcparallel(rcloud.solr::solr.delete.comment(id, cid), detached=TRUE)
+  }
   res <- delete.gist.comment(id,cid, ctx = .rcloud.get.gist.context())
   res$ok
 }

--- a/rcloud.support/R/notebook.protection.R
+++ b/rcloud.support/R/notebook.protection.R
@@ -42,10 +42,13 @@ rcloud.set.notebook.cryptgroup <- function(notebookid, groupid, modify=TRUE) { #
                          stop(e) })
         }
     }
-    ## Remove notebook from SOLR Caching notebook was successfully assigned a crypto group
-    if(is.notebook.encrypted(notebookid)) resp <- rcloud.solr::solr.delete.doc(notebookid)
-    ## If group change is set back to Public update the solr index
-    if(!is.notebook.encrypted(notebookid)) resp <- rcloud.solr::update_solr(rcloud.get.notebook(notebookid,raw=TRUE),rcloud.notebook.star.count(notebookid))
+    if(is.rcloud.solr.feature.enabled()) {
+      ## Remove notebook from SOLR Caching notebook was successfully assigned a crypto group
+      if(is.notebook.encrypted(notebookid)) resp <- rcloud.solr::solr.delete.doc(notebookid)
+      
+      ## If group change is set back to Public update the solr index
+      if(!is.notebook.encrypted(notebookid)) resp <- rcloud.solr::update_solr(rcloud.get.notebook(notebookid,raw=TRUE),rcloud.notebook.star.count(notebookid))
+    }
     invisible(TRUE)
 }
 

--- a/rcloud.support/R/ocaps.R
+++ b/rcloud.support/R/ocaps.R
@@ -324,7 +324,7 @@ authenticated.ocaps <- function(mode)
   )
 
   ## search is optional
-  if (nzConf("solr.url")) {
+  if (is.rcloud.solr.feature.enabled()) {
     changes$rcloud$search <- make.oc(rcloud.solr::rcloud.search)
     changes$rcloud$search_description <- make.oc(rcloud.solr::rcloud.search.description)
   }


### PR DESCRIPTION
Backend not always was checking if solr feature is enabled. Introduced a function that not only checks if solr.url property is set but also if rcloud.solr package is available and added solr feature checks where they were missing.
