### PR TITLE
Use configured view to open notebook from recent list

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -451,8 +451,9 @@ var editor = function () {
                 var gist = $(e.currentTarget).data('gist');
                 $('.dropdown-toggle.recent-btn').dropdown("toggle");
                 if(e.altKey) {
-                  var url = ui_utils.make_url('view.html', {notebook: gist});
-                  window.open(url, "_blank");
+                  RCloud.UI.share_button.resolve_view_link(gist).then(function(url) {
+                    window.open(url, "_blank");
+                  });
                 } else {
                   result.open_notebook(gist, undefined, undefined, undefined, e.metaKey || e.ctrlKey);
                 }

--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -451,7 +451,7 @@ var editor = function () {
                 var gist = $(e.currentTarget).data('gist');
                 $('.dropdown-toggle.recent-btn').dropdown("toggle");
                 if(e.altKey) {
-                  RCloud.UI.share_button.resolve_view_link(gist).then(function(url) {
+                  RCloud.UI.share_button.resolve_view_link(gist, undefined).then(function(url) {
                     window.open(url, "_blank");
                   });
                 } else {

--- a/htdocs/js/ui/share_button.js
+++ b/htdocs/js/ui/share_button.js
@@ -1,31 +1,65 @@
 RCloud.UI.share_button = (function() {
     var extension_;
     var default_item_ = null;
-    function set_page(title) {
+    
+    function set_view_type(title) {
         title = (title && extension_.get(title)) ? title : default_item_;
-        var view_type = extension_.get(title);
         if(!title)
             return Promise.reject(new Error('share button view types set up wrong'));
-        var page = view_type.page;
+        return rcloud.set_notebook_property(shell.gistname(), "view-type", title);
+    }
+    
+    function get_view_type_name(gistname) {
+      return rcloud.get_notebook_property(gistname, "view-type").then(function(title) {
+              title = (title && extension_.get(title)) ? title : default_item_;
+              if(!title)
+                  return Promise.reject(new Error('share button view types set up wrong'));
+              return title;
+      });
+    }
+    
+    function get_view_type(gistname) {
+      return get_view_type_name(gistname).then(function(title) {
+              var view_type = extension_.get(title);
+              return view_type;
+      });
+    }
+
+    function resolve_view_url(gistname, version) {
+          var notebook_options = null;
+          if(version) {
+            fetch_version = rcloud.get_tag_by_version(gistname, version)
+            .then(function(tag) {
+              var opts = {notebook: gistname,
+                    version: x};
+                if(tag) {
+                    opts.tag = tag;
+                }
+                return opts;
+            });
+          } else {
+            notebook_options = Promise.resolve(undefined).then(function(x) {
+              return { notebook: gistname };
+            });
+          }
+          var join = Promise.join;
+          
+          return join(notebook_options, get_view_type(gistname), 
+              function(opts, view_type) {
+                var page = view_type.page;
+                opts.do_path = view_type.do_path;
+                return ui_utils.make_url(page, opts);
+          });
+        }
+        
+    function highlight(title) {
+      if(title) {
         $("#view-type li a").css("font-weight", function() {
             return $(this).text() === title ? "bold" : "normal";
         });
-        var opts = {notebook: shell.gistname(),
-                    do_path: view_type.do_path,
-                    version: shell.version()};
-        var shareable_link = RCloud.UI.navbar.control('shareable_link');
-        if(!opts.version) {
-            shareable_link.set_url(ui_utils.make_url(page, opts));
-            return Promise.resolve(undefined);
-        }
-        else return rcloud.get_tag_by_version(shell.gistname(), opts.version)
-            .then(function(t) {
-                if(t)
-                    opts.tag = t;
-                shareable_link.set_url(ui_utils.make_url(page, opts));
-            });
+      }        
     }
-
+        
     return {
         init: function() {
             extension_ = RCloud.extension.create({
@@ -35,10 +69,15 @@ RCloud.UI.share_button = (function() {
                         return {
                             title: that.key,
                             handler: function() {
-                                rcloud.set_notebook_property(shell.gistname(), "view-type", that.key);
-                                set_page(that.key);
-                                var shareable_link = RCloud.UI.navbar.control('shareable_link');
-                                shareable_link.open();
+                                set_view_type(that.key).then(function() {
+                                    highlight(that.key);
+                                }).then(function() {
+                                  return resolve_view_url(shell.gistname(), shell.version()).then(function(url) {
+                                    var shareable_link = RCloud.UI.navbar.control('shareable_link');
+                                    shareable_link.set_url(url);
+                                    shareable_link.open();
+                                  });
+                                });
                             }
                         };
                     }
@@ -79,20 +118,16 @@ RCloud.UI.share_button = (function() {
             return this;
         },
         update_link: function() {
-            return rcloud.get_notebook_property(shell.gistname(), "view-type")
-                .then(set_page);
+          return resolve_view_url(shell.gistname(), shell.version()).then(function(url) {
+                                  var shareable_link = RCloud.UI.navbar.control('shareable_link');
+                                  shareable_link.set_url(url);
+                                }).then(function() {
+                                  return get_view_type_name(shell.gistname()).then(function(title) {
+                                    highlight(title);
+                                })});
         },
-        resolve_view_link: function(gistname) {
-            return rcloud.get_notebook_property(gistname, "view-type").then(function(title) {
-              title = (title && extension_.get(title)) ? title : default_item_;
-              var view_type = extension_.get(title);
-              if(!title)
-                  return Promise.reject(new Error('share button view types set up wrong'));
-              var page = view_type.page;
-              var opts = {notebook: gistname,
-                      do_path: view_type.do_path};
-              return ui_utils.make_url(page, opts);
-            });
+        resolve_view_link: function(gistname, version) {
+          return resolve_view_url(gistname, version);
         }
     };
 })();

--- a/htdocs/js/ui/share_button.js
+++ b/htdocs/js/ui/share_button.js
@@ -81,6 +81,18 @@ RCloud.UI.share_button = (function() {
         update_link: function() {
             return rcloud.get_notebook_property(shell.gistname(), "view-type")
                 .then(set_page);
+        },
+        resolve_view_link: function(gistname) {
+            return rcloud.get_notebook_property(gistname, "view-type").then(function(title) {
+              title = (title && extension_.get(title)) ? title : default_item_;
+              var view_type = extension_.get(title);
+              if(!title)
+                  return Promise.reject(new Error('share button view types set up wrong'));
+              var page = view_type.page;
+              var opts = {notebook: gistname,
+                      do_path: view_type.do_path};
+              return ui_utils.make_url(page, opts);
+            });
         }
     };
 })();


### PR DESCRIPTION
Added a new method resolve_view_link to RCloud.UI.share_button extension which can be used to resolve URLs of view pages for given notebooks. 