### PR TITLE
Changing sort order should be faster

### DIFF
--- a/htdocs/js/tree/notebook_tree_model.js
+++ b/htdocs/js/tree/notebook_tree_model.js
@@ -902,7 +902,7 @@ notebook_tree_model.prototype = {
                 update_children(this.tree_data_);
 
                 this.on_update_sort_order.notify({
-                    nodes: nodes_and_children,
+                    tree_data: this.tree_data_,
                     sort_type: sort_type
                 });
             }

--- a/htdocs/js/tree/notebook_tree_model.js
+++ b/htdocs/js/tree/notebook_tree_model.js
@@ -883,7 +883,10 @@ notebook_tree_model.prototype = {
 
                             if(o[i].hasOwnProperty('children')) {
 
-                                o[i].children.sort(that.compare_nodes.bind(that));
+                                // don't reorder history nodes:
+                                if(!o[i].children[0].version) {
+                                    o[i].children.sort(that.compare_nodes.bind(that));
+                                }
 
                                 nodes_and_children.push({
                                     node_id: o[i].id,

--- a/htdocs/js/tree/notebook_tree_model.js
+++ b/htdocs/js/tree/notebook_tree_model.js
@@ -783,7 +783,7 @@ notebook_tree_model.prototype = {
                 if (!!o[i] && typeof(o[i])=="object") {
                     if(o[i].hasOwnProperty('children')) {                        
                         current_matches = _.filter(o[i].children, function(child) {
-                            return child.gistname;
+                            return child.gistname && !child.version;
                         });
 
                         set_status(current_matches, false);

--- a/htdocs/js/tree/notebook_tree_view.js
+++ b/htdocs/js/tree/notebook_tree_view.js
@@ -65,16 +65,8 @@ var notebook_tree_view = function(model) {
 
     this.model_.on_update_sort_order.attach(function(sender, args) {
         if(view_obj.$tree_) {
-            // get the state, because 'loadData' doesn't persist selected
-            // or node states:
             var state = view_obj.$tree_.tree('getState');
-
-            _.each(args.nodes, function(node) {
-                var parent = view_obj.$tree_.tree('getNodeById', node.node_id);
-                view_obj.$tree_.tree('loadData', node.children, parent);
-            });
-
-            // restore the state:
+            view_obj.$tree_.tree('loadData', args.tree_data);
             view_obj.$tree_.tree('setState', state);
         }
 

--- a/htdocs/js/tree/notebook_tree_view.js
+++ b/htdocs/js/tree/notebook_tree_view.js
@@ -424,7 +424,12 @@ notebook_tree_view.prototype = {
         element.append(right);
 
         if(node.gistname) {
-            element.parent()[this.model_.does_notebook_match_filter(node.id) ? 'show' : 'hide']();
+            if(node.version) {
+                // history node:
+                element.show();
+            } else {
+                element.parent()[this.model_.does_notebook_match_filter(node.id) ? 'show' : 'hide']();                
+            }
         }
     }
 };

--- a/htdocs/js/tree/notebook_tree_view.js
+++ b/htdocs/js/tree/notebook_tree_view.js
@@ -85,7 +85,9 @@ var notebook_tree_view = function(model) {
         if(view_obj.$tree_) {
             view_obj.$tree_.tree('getTree').iterate(function(node) {
                 if(node.gistname) {
-                    if(args.nodes.indexOf(node.id) != -1) {
+                    if(_.find(args.nodes, function(node_id) {
+                        return node.id.startsWith(node_id);
+                    })) {
                         $(node.element).show();
                     } else {
                         $(node.element).hide();


### PR DESCRIPTION
When I originally thought of the sort order changes, I mistakenly thought that perhaps passing in a list of parent/child nodes would be faster, but the DOM updates were a huge bottleneck (as you found @gordonwoodhull). I overthought this, and now pass in the entire tree, and from my tests, things seem to be faster. I hope that you see a significant improvement on your 'notebook heavy' tree.