### PR TITLE
Remove extra scrollbars from dataframe viewer

### DIFF
--- a/htdocs/js/ui/column.js
+++ b/htdocs/js/ui/column.js
@@ -88,6 +88,17 @@ RCloud.UI.collapsible_column = function(sel_column, sel_accordion, sel_collapser
             collapsibles().on("size-changed", function() {
                 that.resize(true);
             });
+            collapsibles().on('shown.bs.collapse', function() {  
+                 var iframes = $(this).find('iframe');
+                 if (iframes) {
+                   for (var i = 0; i < iframes.length; i++) {
+                    var iframe = iframes.get(i);
+                    if(iframe.contentDocument && iframe.contentDocument.location) {
+                      iframe.contentDocument.location.reload(true);
+                    }
+                   }
+                 }
+            });
             $(sel_collapser).click(function() {
                 if (collapsed_)
                     that.show(true);

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -3,13 +3,11 @@
 
     var viewer_panel = {
         body: function() {
-            return $.el.div({id: "viewer-body-wrapper", 'class': 'panel-body tight'},
-                           $.el.div({id: "viewer-scroller", style: "width: 100%; height: 100%; overflow-x: auto"},
-                                    $.el.div({id:"viewer-body", 'class': 'widget-vsize'})));
+            return $.el.div({id: "viewer-body-wrapper", 'class': 'panel-body tight'});
         }
     };
     function clear_display() {
-        $('#viewer-body > table').remove();
+        $('#viewer-body > div').remove();
     }
 return {
     init: function(k) {
@@ -28,8 +26,8 @@ return {
         k();
     },
     view: function(data, title, k) {
-        $('#viewer-body > div').remove();
-        $('#viewer-body').append($(data));
+        $('#viewer-body-wrapper > div').remove();
+        $('#viewer-body-wrapper').append($(data));
         RCloud.UI.right_panel.collapse($("#collapse-data-viewer"), false, false);
         k();
     }


### PR DESCRIPTION
Rearranged the containers in the dataframe viewer panel and removed the extra scrolling pane. I also had to implement a workaround for bootstrap issue which was not displaying scrollbars in iframes on panels that got expanded after collapsing. FIX #2484