### PR TITLE
Scroll to node after import/recent selection

### DIFF
--- a/htdocs/js/tree/notebook_tree_view.js
+++ b/htdocs/js/tree/notebook_tree_view.js
@@ -273,7 +273,7 @@ notebook_tree_view.prototype = {
             this.$tree_.tree('openNode', p);
             p = p.parent;
         }
-        ui_utils.scroll_into_view(this.$tree_.parent(), 50, 100, null, $(node.element));
+        ui_utils.scroll_into_view(this.$tree_, 50, 100, null, $(node.element));
     },
 
     remove_node: function(node) {
@@ -352,7 +352,7 @@ notebook_tree_view.prototype = {
                     that.$tree_.tree('openNode', p);
                     p = p.parent;
                 }
-                ui_utils.scroll_into_view(that.$tree_.parent(), 150, 150, function() {
+                ui_utils.scroll_into_view(that.$tree_, 150, 150, function() {
                     $(node.element).closest('.jqtree_common').effect('highlight', { color: '#fd0' }, 1500, function() {
                         resolve();
                     });


### PR DESCRIPTION
The fixed header for filtering, sorting caused the issue where the `offsetTop()` call for the first argument to `scroll_into_view` would always return 0.

Updated the selector to the element that scrolls and the correct value is returned and scroll to node works as expected.