### PR TITLE
New folder appears in correct date sort location

### DIFF
--- a/htdocs/js/tree/notebook_tree_model.js
+++ b/htdocs/js/tree/notebook_tree_model.js
@@ -303,9 +303,16 @@ notebook_tree_model.prototype = {
                 return lc;
 
             } else {
-                var dateA = a.last_commit ? new Date(a.last_commit) : _.max(_.map(a.children, function(child) { return new Date(child.last_commit); }));
-                var dateB = b.last_commit ? new Date(b.last_commit) : _.max(_.map(b.children, function(child) { return new Date(child.last_commit); }));
-                return dateB - dateA;
+
+                var get_date = function(node) {
+                    if(!node.last_commit && !node.children) {
+                        return Infinity;
+                    } else {
+                        return node.last_commit ? new Date(node.last_commit) : _.max(_.map(node.children, function(child) { return new Date(child.last_commit); }));                        
+                    }
+                };
+
+                return get_date(b) - get_date(a);
             }            
         }
     },


### PR DESCRIPTION
My code didn't account for newly created folders, which have neither `children` nor a `last_commit` property. The resulting date was incorrect, and resulted in the last place ordering by time.

Referring to the issue, #2501, this change means that newly created folders (resulting from a notebook rename) are put at the top of the date ordering. 

The second case, where a notebook in a folder is deleted and loaded by ID, results in the folder being at the top of the tree.