### PR TITLE
Fix resizing of data frame viewer panel, FIX #2503

### DIFF
--- a/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
+++ b/rcloud.packages/rcloud.enviewer/R/rcloud.enviewer.R
@@ -7,33 +7,6 @@ rcloud.enviewer.view.dataframe <- function(expr) {
   View(get(expr, .GlobalEnv), expr = expr)
 }
 
-#'
-#' @param name data.frame variable name
-#' @param options dataTables request parameters
-#' @return datatables JS result object (see datatables documentation)
-rcloud.enviewer.view.dataframe.page <- function(name, options) {
-  val <- get(name, .GlobalEnv)
-  
-  result <- list(draw = options$draw)
-  
-  if(is.data.frame(val)) {
-    records <- nrow(val)
-    result$recordsTotal <- records
-    result$recordsFiltered <- records 
-    page <- seq(options$start,min(options$start+options$length, records))
-    data <- tryCatch(jsonlite::toJSON(cbind(as.integer(rownames(val)[page]),val[page,]), dataframe = "values"))
-    if(typeof(data) == "try-error") {
-      result$error <- paste0("Could not marshal data.frame data. Error: ", as.character(data))
-    } else {
-      result$data <- data
-    }
-    return(result)
-  } else {
-    result$error <- paste0("Unsupported variable type: ", typeof(val))
-  }
-  return(result)
-}
-
 ## -- how to handle each group --
 rcloud.enviewer.display.dataframe <- function(x, val) {
   structure(list(command="view", object=x, text=paste0("data.frame [",paste(dim(val), collapse=', '),"]")), class="data")

--- a/rcloud.packages/rcloud.enviewer/R/zzz.R
+++ b/rcloud.packages/rcloud.enviewer/R/zzz.R
@@ -11,8 +11,7 @@ rcloud.enviewer.caps <- NULL
   rcloud.enviewer.caps <<- f("rcloud.enviewer", "rcloud.enviewer.js")
   if(!is.null(rcloud.enviewer.caps)) {
     ocaps <- list(refresh = rcloud.support:::make.oc(rcloud.enviewer.refresh),
-                  view_dataframe = rcloud.support:::make.oc(rcloud.enviewer.view.dataframe),
-                  view_dataframe_page = rcloud.support:::make.oc(rcloud.enviewer.view.dataframe.page))
+                  view_dataframe = rcloud.support:::make.oc(rcloud.enviewer.view.dataframe))
     rcloud.enviewer.caps$init(ocaps)
   }
 }

--- a/rcloud.packages/rcloud.enviewer/inst/javascript/rcloud.enviewer.js
+++ b/rcloud.packages/rcloud.enviewer/inst/javascript/rcloud.enviewer.js
@@ -94,39 +94,18 @@
     }
 return {
     init: function(ocaps, k) {
-        ocaps = RCloud.promisify_paths(ocaps, [["refresh"], ["view_dataframe"], ["view_dataframe_page"]], true);
+        ocaps = RCloud.promisify_paths(ocaps, [["refresh"], ["view_dataframe"]], true);
         
-                var dataFrameCallback = function(variable, data, callback, settings) {
-                  var page = window.parent.RCloud.UI.enviewer.view_dataframe_page(variable, data)
-                    .then(function (response) {
-                      var dataObject = {};
-                      var tableData = JSON.parse(response.data);
-                      dataObject.data = tableData;
-                      dataObject.recordsTotal = response.recordsTotal;
-                      dataObject.recordsFiltered = response.recordsTotal;
-                      dataObject.draw = response.draw;
-                      callback(dataObject);
-                    }); 
-                };
         if(window.shell) { // are we running in RCloud UI?
             var state = enviewer_state();
             if(state) {// update with new connection
                 state.ocaps = ocaps;
-                RCloud.UI.enviewer = {
-                              view_dataframe_page : state.ocaps.view_dataframe_page,
-                              dataFrameCallback : dataFrameCallback
-                            };
-                
                 clear_display(); // also would be part of detach
             } else // this listener will outlast the js that loaded it
                 shell.notebook.model.execution_watchers.push({
                     run_cell: function() {
                         var state = enviewer_state();
                         if(state && state.do_refresh) {
-                            RCloud.UI.enviewer = {
-                              view_dataframe_page : state.ocaps.view_dataframe_page,
-                              dataFrameCallback : dataFrameCallback
-                            };
                             state.ocaps.refresh();
                         }
                     }

--- a/rcloud.packages/rcloud.viewer/R/zzz.R
+++ b/rcloud.packages/rcloud.viewer/R/zzz.R
@@ -9,6 +9,8 @@ rcloud.viewer.caps <- NULL
     caps
   }
   rcloud.viewer.caps <<- f("rcloud.viewer", "rcloud.viewer.js")
-  if(!is.null(rcloud.viewer.caps))
-    rcloud.viewer.caps$init()
+  if(!is.null(rcloud.viewer.caps)) {
+    ocaps <- list(view_dataframe_page = rcloud.support:::make.oc(rcloud.viewer.view.dataframe.page))
+    rcloud.viewer.caps$init(ocaps)
+  }
 }

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -1,5 +1,4 @@
 ((function() {
-    var ocaps_;
 
     var viewer_panel = {
         body: function() {
@@ -10,8 +9,28 @@
         $('#viewer-body > div').remove();
     }
 return {
-    init: function(k) {
+    init: function(ocaps, k) {
+        ocaps = RCloud.promisify_paths(ocaps, [["view_dataframe_page"]], true);
+        
         clear_display();
+                            
+               
+        RCloud.UI.viewer = {
+              view_dataframe_page : ocaps.view_dataframe_page,
+              dataFrameCallback : function(variable, data, callback, settings) {
+                  var page = window.parent.RCloud.UI.viewer.view_dataframe_page(variable, data)
+                        .then(function (response) {
+                            var dataObject = {};
+                            var tableData = JSON.parse(response.data);
+                            dataObject.data = tableData;
+                            dataObject.recordsTotal = response.recordsTotal;
+                            dataObject.recordsFiltered = response.recordsTotal;
+                            dataObject.draw = response.draw;
+                            callback(dataObject);
+                  }); 
+              }
+        };
+        
         RCloud.UI.panel_loader.add({
             Dataframe: {
                 side: 'right',

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -27,7 +27,21 @@ return {
     },
     view: function(data, title, k) {
         $('#viewer-body-wrapper > div').remove();
-        $('#viewer-body-wrapper').append($(data));
+        $('#collapse-data-viewer').data('panel-sizer', function(panel) {
+          var widgetDiv = $(panel).find('.rcloud-htmlwidget-content');
+          var height = widgetDiv.data('panel-initial-height'); 
+          var padding = RCloud.UI.collapsible_column.default_padder(panel);
+          return {height: height, padding: padding};
+        });
+        var widgetDiv = $(data);
+        widgetDiv.height('100%');
+        var iframe = widgetDiv.find('iframe');
+        if(iframe.length > 0) {
+          // override whatever fixed value is set on iframe, so it can be resized by column.js
+          widgetDiv.data('panel-initial-height', iframe.get(0).height);
+          iframe.get(0).height = '100%';
+        }
+        $('#viewer-body-wrapper').append(widgetDiv);
         RCloud.UI.right_panel.collapse($("#collapse-data-viewer"), false, false);
         k();
     }


### PR DESCRIPTION
This change makes sure that:
* height of htmlwidget iframe is provided to the resizing algorithm, instead of null.
* htmlwidget iframe hard-coded height does not override whatever value panel resizing algorithm sets on the panel (this was resulting in iframe overflowing the panel)