### PR TITLE
 Fix auto-completion in rmarkdown ACE editor mode.

### DIFF
--- a/htdocs/lib/js/ace/mode-r.js
+++ b/htdocs/lib/js/ace/mode-r.js
@@ -110,8 +110,18 @@ define("ace/mode/r", function(require, exports, module)
          }
          return false;
       };
-  
+      
       this.lineCommentStart = ["#"];
+      
+      this.getCompletionsAsync = function(state, session, pos, callback) {
+        if(this.$completer) {
+          this.$completer.getCompletions(null, session, pos, callback);
+        } else {
+          callback(null, []);
+        }
+      };
+      
+      this.$id = "ace/mode/r";
    }).call(Mode.prototype);
    exports.Mode = Mode;
 });

--- a/htdocs/lib/js/ace/rmarkdown.js
+++ b/htdocs/lib/js/ace/rmarkdown.js
@@ -43,6 +43,8 @@ var Mode = function(suppressHighlighting, doc, session) {
          true);
 
     this.createModeDelegates({
+        "jscode2-": JavaScriptMode,
+        "csscode2-": CssMode,
         "jscode-": JavaScriptMode,
         "csscode-": CssMode,
         "r-": RMode


### PR DESCRIPTION
There are two commits in this pull request:
* first fixes auto-completion in (r)markdown cells
* second makes sure that rmarkdown mode which is used for both: Rmarkdown and markdown editor cells correctly handles language blocks in both 'formats' (in Rmarkdown, language name is wrapped in extra curly braces).

I split this into two commits because the second commit is based on an assumption that rmarkdown mode being used for both markdown and Rmarkdown cells is not a bug and it is intentional, but the assumption may be wrong.

FIX #2429 