### PR TITLE
Autoscroll output in notebook pane when cell is executed.

### DIFF
--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -774,6 +774,7 @@ function create_cell_html_view(language, cell_model) {
             }
             this.state_changed(error ? 'error' : running_state_==='unknown-running' ? 'ready' : 'complete');
             current_result_ = current_error_ = null;
+            this.scroll_to_result();
         },
         clear_result: clear_result,
         set_readonly: function(readonly) {
@@ -927,6 +928,19 @@ function create_cell_html_view(language, cell_model) {
                 source_div_.show();
                 edit_button_border(true);
             }
+        },
+        should_scroll: function() {
+            return ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, source_div_]) &&
+                   !ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, result_div_]);
+        },
+        scroll_to_result: function() {
+            var that = this;
+            ui_utils.on_next_tick(function() {
+                var cellarea = $('#rcloud-cellarea');
+                if(result_div_ && that.should_scroll()) {
+                  ui_utils.scroll_to_after(result_div_, undefined, cellarea, [notebook_cell_div], cellarea.height());
+                }
+            });
         },
         toggle_results: function(val) {
             if(val===undefined)

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -30,6 +30,7 @@ function create_cell_html_view(language, cell_model) {
     var highlights_;
     var code_preprocessors_ = []; // will be an extension point, someday
     var running_state_;  // running state
+    var running_ui_state_ = {add_result: {}};
 
     // input1
     var prompt_text_;
@@ -718,6 +719,7 @@ function create_cell_html_view(language, cell_model) {
                     result.hide_source(true);
                 has_result_ = true;
             }
+            running_ui_state_.add_result.result_div_visible_in_cellarea = this.is_result_div_visible_in_cellarea();
             this.toggle_results(true); // always show when updating
             switch(type) {
             case 'selection':
@@ -764,6 +766,7 @@ function create_cell_html_view(language, cell_model) {
             default:
                 throw new Error('unknown result type ' + type);
             }
+            this.scroll_to_result(running_ui_state_.add_result);
             result_updated();
         },
         end_output: function(error) {
@@ -774,7 +777,7 @@ function create_cell_html_view(language, cell_model) {
             }
             this.state_changed(error ? 'error' : running_state_==='unknown-running' ? 'ready' : 'complete');
             current_result_ = current_error_ = null;
-            this.scroll_to_result();
+            this.scroll_to_result(running_ui_state_.add_result);
         },
         clear_result: clear_result,
         set_readonly: function(readonly) {
@@ -929,15 +932,18 @@ function create_cell_html_view(language, cell_model) {
                 edit_button_border(true);
             }
         },
-        should_scroll: function() {
-            return ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, source_div_]) &&
-                   !ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, result_div_]);
+        is_result_div_visible_in_cellarea: function() {
+            return ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, result_div_]);
         },
-        scroll_to_result: function() {
+        scroll_to_result: function(previous_state) {
             var that = this;
+            var shouldScroll = false;
+            if(previous_state) {
+              shouldScroll = previous_state.result_div_visible_in_cellarea && !that.is_result_div_visible_in_cellarea();
+            }
             ui_utils.on_next_tick(function() {
                 var cellarea = $('#rcloud-cellarea');
-                if(result_div_ && that.should_scroll()) {
+                if(result_div_ && shouldScroll) {
                   ui_utils.scroll_to_after(result_div_, undefined, cellarea, [notebook_cell_div], cellarea.height());
                 }
             });

--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -31,6 +31,7 @@ function create_cell_html_view(language, cell_model) {
     var code_preprocessors_ = []; // will be an extension point, someday
     var running_state_;  // running state
     var running_ui_state_ = {add_result: {}};
+    var autoscroll_notebook_output_;
 
     // input1
     var prompt_text_;
@@ -796,6 +797,9 @@ function create_cell_html_view(language, cell_model) {
         set_show_cell_numbers: function(whether) {
             left_controls_.set_flag('cell-numbers', whether);
         },
+        set_autoscroll_notebook_output: function(whether) {
+            autoscroll_notebook_output_ = whether;
+        },
         click_to_edit: click_to_edit,
 
         //////////////////////////////////////////////////////////////////////
@@ -941,6 +945,9 @@ function create_cell_html_view(language, cell_model) {
             if(previous_state) {
               shouldScroll = previous_state.result_div_visible_in_cellarea && !that.is_result_div_visible_in_cellarea();
             }
+            
+            shouldScroll = shouldScroll && autoscroll_notebook_output_;
+            
             ui_utils.on_next_tick(function() {
                 var cellarea = $('#rcloud-cellarea');
                 if(result_div_ && shouldScroll) {

--- a/htdocs/js/notebook/notebook_controller.js
+++ b/htdocs/js/notebook/notebook_controller.js
@@ -568,7 +568,12 @@ Notebook.create_controller = function(model)
             });
             return this;
         },
-
+        autoscroll_notebook_output: function(whether) {
+            _.each(model.views, function(view) {
+                view.set_autoscroll_notebook_output(whether);
+            });
+            return this;
+        },
         //////////////////////////////////////////////////////////////////////
 
         is_mine: function() {

--- a/htdocs/js/notebook/notebook_view.js
+++ b/htdocs/js/notebook/notebook_view.js
@@ -1,6 +1,7 @@
 Notebook.create_html_view = function(model, root_div)
 {
     var show_cell_numbers_;
+    var autoscroll_notebook_output_;
     function on_rearrange() {
         _.each(result.sub_views, function(view) {
             view.check_buttons();
@@ -10,6 +11,7 @@ Notebook.create_html_view = function(model, root_div)
     function init_cell_view(cell_view) {
         cell_view.set_readonly(model.read_only() || shell.is_view_mode());
         cell_view.set_show_cell_numbers(show_cell_numbers_);
+        cell_view.set_autoscroll_notebook_output(autoscroll_notebook_output_);
     }
 
     var result = {
@@ -73,6 +75,12 @@ Notebook.create_html_view = function(model, root_div)
             show_cell_numbers_ = whether;
             _.each(this.sub_views, function(view) {
                 view.set_show_cell_numbers(whether);
+            });
+        },
+        set_autoscroll_notebook_output: function(whether) {
+            autoscroll_notebook_output_ = whether;
+            _.each(this.sub_views, function(view) {
+                view.set_autoscroll_notebook_output(whether);
             });
         },
         update_urls: function() {

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -191,6 +191,14 @@ RCloud.UI.settings_frame = (function() {
                         RCloud.UI.import_export.export_only_selected_files(val);
                     }
                 }),
+                'autoscroll-notebook-output': that.checkbox({
+                    sort: 6500,
+                    default_value: true,
+                    label: "Autoscroll notebook",
+                    set: function(val) {
+                        shell.notebook.controller.autoscroll_notebook_output(val);
+                    }
+                }),
                 'addons': that.text_input_vector({
                     sort: 10000,
                     needs_reload: true,

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -650,8 +650,9 @@ ui_utils.is_visible_in_scrollable = function($scroller, $offset_elements) {
   
     var height = +$scroller.css("height").replace("px","");
     var elemtoppos = ui_utils.get_top_offset($offset_elements);
-    
-    elemtoppos += $offset_elements[$offset_elements.length-1].outerHeight();
+    if($($offset_elements[$offset_elements.length-1]).is(":visible")) {
+      elemtoppos += $offset_elements[$offset_elements.length-1].outerHeight();
+    }
     elemtoppos -= $scroller.get(0).offsetTop;
     return (elemtoppos <= height)
 };


### PR DESCRIPTION
The scroll will only be performed if the executed cell's input is visible and output would not fit into displayed area in the notebook pane.

FIX #2222 

I also investigated what would be involved in applying different autoscroll strategies depending on:
* if 'Run All' was selected
* if the prompt cell was visible when bulk of cells got executed.
and in such case autoscroll to cell outputs despite visibility of their source.

Supporting the above would require a bit more work, as the view would need to be aware of the state of the view when execution got triggered and use it when results are rendered to apply autoscrolling. 

Implementing these however do have some implications on user experience - e.g. when a user runs all cells, the notebook pane would scroll until all cells got processed, this may not necessarily be user-friendly if there are a few htmlwidgets in the notebook. Also we could potentially want to disable autoscrolling during execution of all cells, if user manually scrolls the notebook pane. 

@gordonwoodhull, what do you think? Should I have a look at this?