### PR TITLE
Add colour coding to recent notebooks dropdown

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -5,7 +5,8 @@ var editor = function () {
         github_nonfork_warning = ["GitHub returns the same notebook if you fork a notebook more than once, so you are seeing your old fork of this notebook.",
                                   "If you want to fork the latest version, open your fork in GitHub (through the Advanced menu) and delete it. Then fork the notebook again."].join(' '),
         NOTEBOOK_LOAD_FAILS = 5,
-        tree_controller_;
+        tree_controller_,
+        color_recent_notebooks_by_modification_date_;
 
     function has_notebook_info(gistname) {
         return tree_controller_.has_notebook_info(gistname);
@@ -322,6 +323,9 @@ var editor = function () {
         set_terse_dates: function(val) {
             this.show_terse_dates_ = val;
         },
+        color_recent_notebooks_by_modification_date: function(val) {
+            this.color_recent_notebooks_by_modification_date_ = val;
+        },
         star_and_show: function(notebook, make_current, is_change) {
             return this.star_notebook(true, {notebook: notebook,
                                              make_current: make_current,
@@ -416,6 +420,58 @@ var editor = function () {
             return rcloud.config.get_recent_notebooks()
                 .then(this.populate_recent_notebooks_list.bind(this));
         },
+        create_recent_notebooks_color_coder: function() {
+          var backgroundColorStyler = function(i, element, dateWt) {
+              var styles = [];
+              for(var j = 0; j < 5; j++) {
+                styles.push('recent-notebooks-group-' + j)
+              }
+              var component = 2;
+              var $elem = $(element);
+              styles.forEach(function(style, i) {
+                $elem.removeClass(style);
+              });
+              $elem.addClass(styles[~~((dateWt) * styles.length)]);
+            };
+            
+          if(this.color_recent_notebooks_by_modification_date_) {
+            var styleByCommitDate = function(elements, styler) {
+                  if(!styler) {
+                    styler = backgroundColorStyler
+                  }
+                  var commitTimes = elements.map(function(x,y) { 
+                    return get_notebook_info($(y).data('gist')).last_commit; 
+                  }).map(function(x,y) { return Date.parse(y); }).sort();
+                  elements.each(function(i, elem) {
+                    var $self = $(elem),
+                        notebook_id = $self.data('gist');
+                    var lastCommit = Date.parse(get_notebook_info(notebook_id).last_commit);
+                    var dateWt = commitTimes.index(lastCommit)/commitTimes.length;
+                    styler(i, elem, dateWt)
+                  });
+            };
+            return styleByCommitDate;
+          } else {
+            var styleByLastAccessDate = function(elements, styler) {
+                  if(!styler) {
+                    styler = backgroundColorStyler
+                  }
+                  var currentDate = Date.now();
+                  var oldest = $(elements[elements.length-1]).data('last-access');
+                  var scalingFactor = currentDate - oldest;
+                  var noOfElements = elements.length;
+                  elements.each(function(i, elem) {
+                    var $self = $(elem),
+                        notebook_id = $self.data('gist');
+                    var lastAccess = $self.data('last-access');
+                    var dateWt = 1-(currentDate - lastAccess)/scalingFactor;
+                    styler(i, elem, dateWt);
+                  });
+            };
+            return styleByLastAccessDate; 
+          }
+        },
+        
         populate_recent_notebooks_list: function(data) {
             var that = this;
             var firstRecentNotebooksBatchSize = 10;
@@ -460,7 +516,7 @@ var editor = function () {
                 var li = $('<li></li>');
                 li.appendTo($('.recent-notebooks-list'));
                 var currentNotebook = that.get_notebook_info(notebook[0]);
-                var anchor = $('<a data-gist="'+notebook[0]+'"></a>');
+                var anchor = $('<a data-gist="'+notebook[0]+'" data-last-access="'+notebook[1]+'"></a>');
                 var desc = truncateNotebookPath(currentNotebook.description, 40);
                 var $desc;
 
@@ -476,36 +532,6 @@ var editor = function () {
 
                 anchor.click(click_recent);
             }
-            
-            function backgroundColorStyler(i, element, dateWt) {
-              var styles = [];
-              for(var j = 0; j < 5; j++) {
-                styles.push('recent-notebooks-group-' + j)
-              }
-              var component = 2;
-              var $elem = $(element);
-              styles.forEach(function(style, i) {
-                $elem.removeClass(style);
-              });
-              $elem.addClass(styles[~~((dateWt) * styles.length)]);
-            }
-            
-            function styleByCommitDate(elements, styler) {
-                  if(!styler) {
-                    styler = backgroundColorStyler
-                  }
-                  var commitTimes = elements.map(function(x,y) { 
-                    return get_notebook_info($(y).data('gist')).last_commit; 
-                  }).map(function(x,y) { return Date.parse(y); }).sort();
-                  elements.each(function(i, elem) {
-                    var $self = $(elem),
-                        notebook_id = $self.data('gist');
-                    var lastCommit = Date.parse(get_notebook_info(notebook_id).last_commit);
-                    var dateWt = commitTimes.index(lastCommit)/commitTimes.length;
-                    styler(i, elem, dateWt)
-                  });
-            }
-            
             for(var i = 0; i < sorted.length; i ++) {
                 create_recent_link(sorted[i])
             }
@@ -532,7 +558,7 @@ var editor = function () {
                     moreLink.appendTo($('.recent-notebooks-list'));
                   }
                   
-                  styleByCommitDate($('.recent-notebooks-list li a[data-gist]'))
+                  that.create_recent_notebooks_color_coder()($('.recent-notebooks-list li a[data-gist]'))
                 });
               };
 
@@ -545,7 +571,7 @@ var editor = function () {
                 .appendTo(li);
 
               anchor.click(loadMore);
-              styleByCommitDate($('.recent-notebooks-list li a[data-gist]'))
+              that.create_recent_notebooks_color_coder()($('.recent-notebooks-list li a[data-gist]'))
             }
 
             function truncateNotebookPath(txt, chars) {

--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -476,9 +476,40 @@ var editor = function () {
 
                 anchor.click(click_recent);
             }
+            
+            function backgroundColorStyler(i, element, dateWt) {
+              var styles = [];
+              for(var j = 0; j < 5; j++) {
+                styles.push('recent-notebooks-group-' + j)
+              }
+              var component = 2;
+              var $elem = $(element);
+              styles.forEach(function(style, i) {
+                $elem.removeClass(style);
+              });
+              $elem.addClass(styles[~~((dateWt) * styles.length)]);
+            }
+            
+            function styleByCommitDate(elements, styler) {
+                  if(!styler) {
+                    styler = backgroundColorStyler
+                  }
+                  var commitTimes = elements.map(function(x,y) { 
+                    return get_notebook_info($(y).data('gist')).last_commit; 
+                  }).map(function(x,y) { return Date.parse(y); }).sort();
+                  elements.each(function(i, elem) {
+                    var $self = $(elem),
+                        notebook_id = $self.data('gist');
+                    var lastCommit = Date.parse(get_notebook_info(notebook_id).last_commit);
+                    var dateWt = commitTimes.index(lastCommit)/commitTimes.length;
+                    styler(i, elem, dateWt)
+                  });
+            }
+            
             for(var i = 0; i < sorted.length; i ++) {
                 create_recent_link(sorted[i])
             }
+            
             if (totalRecentNotebooks > firstRecentNotebooksBatchSize) {
               var that = this;
               var loadMore = function(e) {
@@ -500,6 +531,8 @@ var editor = function () {
                   if(!isLastBatch) {
                     moreLink.appendTo($('.recent-notebooks-list'));
                   }
+                  
+                  styleByCommitDate($('.recent-notebooks-list li a[data-gist]'))
                 });
               };
 
@@ -512,6 +545,7 @@ var editor = function () {
                 .appendTo(li);
 
               anchor.click(loadMore);
+              styleByCommitDate($('.recent-notebooks-list li a[data-gist]'))
             }
 
             function truncateNotebookPath(txt, chars) {

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -169,6 +169,14 @@ RCloud.UI.settings_frame = (function() {
                         shell.notebook.controller.show_cell_numbers(val);
                     }
                 }),
+                'color-recent-notebooks-by-modification-date': that.checkbox({
+                    sort: 3500,
+                    default_value: false,
+                    label: "Color recent notebooks by modification date",
+                    set: function(val) {
+                        editor.color_recent_notebooks_by_modification_date(val);
+                    }
+                }),
                 'panel-layout-by-size': that.checkbox({
                     sort: 4000,
                     default_value: true,

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -617,6 +617,28 @@ ul.recent-notebooks-list li a {
     white-space: nowrap;
 }
 
+/* color-coding of recent notebooks */
+
+.recent-notebooks-group-0 {
+  background-color: #f2e8fd;
+}
+
+.recent-notebooks-group-1 {
+  background-color: #fdf2e8;
+}
+
+.recent-notebooks-group-2 {
+  background-color: #fdfde8;
+}
+
+.recent-notebooks-group-3 {
+  background-color: #f8fde8;
+}
+
+.recent-notebooks-group-4 {
+  background-color: #e9fde8;
+}
+
 /* tree filtering and ordering */
 .notebook-tree {
     padding: 0;


### PR DESCRIPTION
Introduced five styles that control background of items in recent notebooks dropdown, these styles are then used by a styling function when recent notebooks dropdown is populated.

I used lighter colours than the ones suggested in the ticket, as simple 'orange', 'yellow' and others seemed too 'invasive', as these are controlled by CSS we can easily change them:

![image](https://user-images.githubusercontent.com/578443/34720330-3a16e816-f536-11e7-8fa1-6f99a8aeaa00.png)

FIX #2462 
