### PR TITLE
pass params.username for use in rcloud.solr search description

### DIFF
--- a/htdocs/js/tree/notebook_tree_search_service.js
+++ b/htdocs/js/tree/notebook_tree_search_service.js
@@ -7,7 +7,7 @@ notebook_tree_search_service.prototype = {
         // params.notebook
         // params.username
         return new Promise(function(resolve) {
-            return rcloud.search_description(params.notebook).then(function(res) {                 
+            return rcloud.search_description(params.notebook, params.username).then(function(res) {                 
                 resolve(
                     _.map(res.response.docs, function(item) {
                         return {


### PR DESCRIPTION
Username missed from call. 
Update also made to rcloud.solr to incorporate username 
Fixes #2517 