### PR TITLE
Update handling of cells with unknown states

### DIFF
--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -678,8 +678,10 @@ function create_cell_html_view(language, cell_model) {
         },
         state_changed: function(state) {
             var control = left_controls_.controls['run_state'];
-            if(running_state_==="unknown" && state==="running")
+            if(running_state_==="unknown" && state==="running") {
                 state = "unknown-running";
+                has_result_ = false;
+            }
             switch(state) {
             case 'ready':
                 control.icon('icon-circle-blank').color('#777').title('content has not been run');
@@ -692,7 +694,6 @@ function create_cell_html_view(language, cell_model) {
                 break;
             case 'unknown-running':
                 control.icon('icon-question icon-spin').color('blue').title('cell is currently running');
-                has_result_ = false;
                 break;
             case 'running':
                 control.icon('icon-spinner icon-spin').color('blue').title('cell is currently running');
@@ -772,7 +773,7 @@ function create_cell_html_view(language, cell_model) {
                 result_div_.empty();
                 has_result_ = true;
             }
-            this.state_changed(error ? 'error' : running_state_==='unknown-running' ? 'ready' : 'complete');
+            this.state_changed(error ? 'error' : running_state_==='unknown-running' ? 'unknown' : 'complete');
             current_result_ = current_error_ = null;
         },
         clear_result: clear_result,


### PR DESCRIPTION
Make sure that result div of running cells is not cleaned up on edit so the output is displayed.
Also use 'unknown' state as the final state for such cells, not 'Ready'.

FIX #2529