### PR TITLE
Attach source file to parsed cells

### DIFF
--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -225,7 +225,7 @@ rcloud.call.notebook <- function(id, version = NULL, args = NULL, attach = FALSE
     ## sort
     for (o in p[match(sort.int(i), i)]) {
       if (grepl("^part.*\\.R$", o$filename)) { ## R code
-        expr <- parse(text=o$content)
+        expr <- parse(text=o$content, srcfile = srcfilecopy(o$filename, o$content))
         result <- eval(expr, e)
         rcloud.flush.plot()
       } else if (grepl("^part.*\\.md", o$filename)) { ## markdown


### PR DESCRIPTION
Shiny 'showcase' mode uses srcfile information to trace back the code that is executed so appropriate parts of code can be highlighted. Without this information the source file reference is always set to '<text>' and code lookup in Shiny dashboard fails

This change makes sure that the parsed cell code has the source file attached.