### PR TITLE
Update recent notebooks color coding rules

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -424,9 +424,10 @@ var editor = function () {
                 .then(this.populate_recent_notebooks_list.bind(this));
         },
         create_recent_notebooks_color_coder: function() {
+          var GROUP_COUNT = 7;
           var backgroundColorStyler = function(i, element, dateWt) {
               var styles = [];
-              for(var j = 0; j < 7; j++) {
+              for(var j = 0; j < GROUP_COUNT; j++) {
                 styles.push('recent-notebooks-group-' + j)
               }
               var component = 2;
@@ -505,7 +506,44 @@ var editor = function () {
                     styler(i, elem, dateWt);
                   });
             };
-            return styleByLastAccessDate; 
+            var styleByLastAccessDate2 = function(elements, styler) {
+                  if(!styler) {
+                    styler = backgroundColorStyler
+                  }
+                  var MINUTE = 1000*60;
+                  var HOUR = 60*MINUTE;
+                  var previous = $(elements[0]).data('last-access');
+                  
+                  var bucket = 0;
+                  var THRESHOLD = 8*HOUR;
+                  var mapping = [];
+                  for (var i=0; i < GROUP_COUNT; i++) {
+                    mapping.push((i+1)/GROUP_COUNT);
+                  }
+                  
+                  function mapValue(value, baseThreshold) {
+                    var threshold = baseThreshold
+                    if(bucket > (mapping.length-3)) {
+                      threshold = 3*threshold;
+                    } 
+                    if (value > threshold) {
+                      if(bucket < (mapping.length-1)) {
+                        bucket++;
+                      }
+                    }
+                    return mapping[bucket];
+                  }
+                  
+                  elements.each(function(i, elem) {
+                    var $self = $(elem),
+                        notebook_id = $self.data('gist');
+                    var lastAccess = $self.data('last-access');
+                    var age = previous - lastAccess;
+                    var dateWt = 1 - mapValue(age, THRESHOLD);
+                    styler(i, elem, dateWt);
+                  });
+            };
+            return styleByLastAccessDate2; 
           }
         },
         

--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -607,11 +607,11 @@ ul.recent-notebooks-list li a {
 /* color-coding of recent notebooks */
 
 .recent-notebooks-group-0 {
-  background-color: #f2e8fd;
+  background-color: #e9fde8;
 }
 
 .recent-notebooks-group-1 {
-  background-color: #fdf2e8;
+  background-color: #f8fde8;
 }
 
 .recent-notebooks-group-2 {
@@ -619,11 +619,19 @@ ul.recent-notebooks-list li a {
 }
 
 .recent-notebooks-group-3 {
-  background-color: #f8fde8;
+  background-color: #fdf2e8;
 }
 
 .recent-notebooks-group-4 {
-  background-color: #e9fde8;
+  background-color: #fde8e8;
+}
+
+.recent-notebooks-group-5 {
+  background-color: #f8e8fd;
+}
+
+.recent-notebooks-group-6 {
+  background-color: #f2e8fd;
 }
 
 /* tree filtering and ordering */


### PR DESCRIPTION
Couple of improvements to color-coding of recent notebooks list:
* removed duplicated functions which I must have missed out before
* made sure that removed notebooks are not included in the list of recent notebooks - they were displayed with 'null' user and 'something went wrong' description.
* added two more background colors styles

There are actually two implementations, you can switch between them by changing styleByLastAccessDate2 to styleByLastAccessDate in here: https://github.com/att/rcloud/compare/develop...MangoTheCat:features/issue-2462-2?expand=1#diff-2c2db8c6ac70968f344116281adbc075R546

styleByLastAccessDate performs color-coding by grouping the notebooks using fixed list of rules: 1,2,3,7,14,31 days from accessing the most recent notebook on the list
styleByLastAccessDate2 (default) performs color-coding by detecting 'gaps' between subsequent notebooks in the history. This implementation captures 'sequences' of notebooks accessed during a single 'session'. The classification rule is that two subsequent notebooks are in the same session if the gap between their access times is less than a given threshold. The threshold is 'dynamic' and for the first five groups is 8h, after that it is increased to 24h - this way first five groups represent 'days' and next groups represent weeks (and more).

I included both so you can test them and compare the results in an environment with some 'proper' activity history - my rcloud instance has too few notebooks with too large gaps between access times.
