### PR TITLE
change code field to text_general

### DIFF
--- a/conf/solr/schema.xml
+++ b/conf/solr/schema.xml
@@ -34,7 +34,7 @@
 <field name="raw_url" type="text_general" indexed="true" stored="true"/>
 <field name="size" type="int" indexed="false" stored="true"/>
 <field name="content" type="text_general" indexed="true" stored="true" multiValued="true"/>
-<field name="code" type="string" indexed="true" stored="true" multiValued="false" />    
+<field name="code" type="text_general" indexed="true" stored="true" multiValued="false" />    
 </fields>
 
 <uniqueKey>id</uniqueKey>


### PR DESCRIPTION
Fixes #2547 

The code field is a copyField from content. Right now I'm not sure we're using it for much, so maybe it should be removed. I'm mainly leaving it in in case we want to add a custom filter for it.

Afraid I think it'll require a rebuild. Although might be able to use the [schema API](https://lucene.apache.org/solr/guide/6_6/schema-api.html#SchemaAPI-ReplaceaField) to run a quick test