### PR TITLE
Dataframe viewer improvements

### DIFF
--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -231,21 +231,6 @@ RCloud.UI.settings_frame = (function() {
                             .filter(function(x, i, a) { return i==a.length-1 || !Notebook.empty_for_github(x); })
                             .join('/');
                     }
-                }),
-                'dataframe-page-size': that.text_input({
-                    sort: 13000,
-                    label: "Dataframe page size",
-                    default_value: "20",
-                    parse: function(val) {
-                        var defaultValue = 20, 
-                            parsed = parseInt(val);
-
-                        if(isNaN(parsed)) {
-                            return defaultValue;
-                        } else {
-                            return parsed < 1 ? 1 : parsed;
-                        }
-                    }
                 })
             });
         },

--- a/htdocs/js/ui/settings_frame.js
+++ b/htdocs/js/ui/settings_frame.js
@@ -231,6 +231,21 @@ RCloud.UI.settings_frame = (function() {
                             .filter(function(x, i, a) { return i==a.length-1 || !Notebook.empty_for_github(x); })
                             .join('/');
                     }
+                }),
+                'dataframe-page-size': that.text_input({
+                    sort: 13000,
+                    label: "Dataframe page size",
+                    default_value: "20",
+                    parse: function(val) {
+                        var defaultValue = 20, 
+                            parsed = parseInt(val);
+
+                        if(isNaN(parsed)) {
+                            return defaultValue;
+                        } else {
+                            return parsed < 1 ? 1 : parsed;
+                        }
+                    }
                 })
             });
         },

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -1,0 +1,3 @@
+body {
+    padding: 0!important;
+}

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -11,7 +11,13 @@ table.dataTable thead th {
 
 .dataTables_wrapper {
 
+    .dataTables_info {
+        float: left!important;
+    }
+
     .dataTables_paginate {
+        float: right!important;
+        margin-top: 0!important;
         .paginate_button {
             background-color: #428bca;
             border-color: #357ebd;

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -6,13 +6,20 @@ body {
 
 table.dataTable tbody td,
 table.dataTable thead th {
-    padding: 4px 5px;
+    padding: 0;
 }
 
 .dataTables_wrapper {
 
     .dataTables_info {
         float: left!important;
+        padding-top: 0;
+        margin-top: -5px;
+    }
+
+    .dataTables_length {
+        text-align: left;
+        padding-top: 3px;
     }
 
     .dataTables_paginate {

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -1,3 +1,30 @@
 body {
     padding: 0!important;
 }
+
+.dataTables_wrapper {
+    .dataTables_paginate {
+        .paginate_button {
+            background-color: #428bca;
+            border-color: #357ebd;
+            color: white!important;
+        
+            &:hover {
+                color: #ffffff;
+                background-color: #3276b1;
+                border-color: #285e8e;
+                background-image: none;
+            }
+
+            &.disabled {
+                background: lighten(#428bca, 15%);
+                color: #fff!important;
+
+                &:hover {
+                    background: lighten(#428bca, 15%);
+                    color: #fff!important;
+                }
+            }
+        }
+    }
+}

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -1,14 +1,24 @@
+@import "utils/utils.scss";
+
 body {
     padding: 0!important;
 }
 
+table.dataTable tbody td,
+table.dataTable thead th {
+    padding: 4px 5px;
+}
+
 .dataTables_wrapper {
+
     .dataTables_paginate {
         .paginate_button {
             background-color: #428bca;
             border-color: #357ebd;
             color: white!important;
-        
+            padding: 4px 6px;
+            @include no-select();
+
             &:hover {
                 color: #ffffff;
                 background-color: #3276b1;

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -7,6 +7,18 @@ body {
 table.dataTable tbody td,
 table.dataTable thead th {
     padding: 0;
+
+    &:first-child {
+        border-right: 1px solid #ddd;
+    }
+}
+
+table.dataTable thead th {
+    border-right: 1px solid #ddd;
+
+    &:last-child {
+        border-right: none;
+    }
 }
 
 .dataTables_wrapper {
@@ -50,5 +62,12 @@ table.dataTable thead th {
                 }
             }
         }
+    }
+}
+
+.row {
+    > div {
+        padding-left: 0;
+        padding-right: 0;
     }
 }

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -32,6 +32,7 @@ table.dataTable thead th {
     .dataTables_length {
         text-align: left;
         padding-top: 3px;
+        float: left!important;
     }
 
     .dataTables_paginate {

--- a/htdocs/sass/rcloud-viewer.scss
+++ b/htdocs/sass/rcloud-viewer.scss
@@ -35,6 +35,7 @@ table.dataTable thead th {
             &.disabled {
                 background: lighten(#428bca, 15%);
                 color: #fff!important;
+                cursor: not-allowed;
 
                 &:hover {
                     background: lighten(#428bca, 15%);

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -18,7 +18,6 @@ defaultEnviewerDTOptions <- function() {
 View <- function (x, title, expr)
 {
   # borrow pre-processing from base R, replace the final command
-  
   if(!missing(expr)) {
     varName <- expr
   } else {

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -79,13 +79,13 @@ renderDataFrame <- function(varName, varValue, title) {
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
       options$ajax <- JS(paste0('function(data, callback, settings) {
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
-        window.parent.RCloud.UI.viewer.initialiseTable($(document));
+        window.parent.RCloud.UI.viewer.initialiseTable();
         window.parent.RCloud.UI.viewer.dataFrameCallback("', varName, '", data, callback, settings);
     }
     }'))
       data <- data.frame(matrix(ncol = ncol(varValue), nrow = 0))
       names(data) <- names(varValue)
-      x <- paste0('<script type="text/javascript">window.parent.RCloud.UI.viewer.initialiseTable(document);</script>', as.character(DT::datatable(data, caption = title, options = options, style = 'default', width = "100%")))
+      x <- as.character(DT::datatable(data, caption = title, options = options, style = 'default', width = "100%"))
     } else {
       x <- paste0('<div><span>Data frame "', varName, '" is empty.</span></div>')
     }

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -88,6 +88,7 @@ renderDataFrame <- function(varName, varValue, title) {
       options$drawCallback <- JS('function() { 
         if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
           $("html, body").animate({ scrollTop: 0 }, "fast");
+          $(".dataTables_paginate")[$(".dataTables_paginate a.disabled").length == $(".dataTables_paginate a").length ? "hide" : "show"]();
         }
       }')
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -23,6 +23,13 @@ defaultEnviewerDTOptions <- function() {
   options$fixedHeader = TRUE
   options$lengthMenu = validLengths
   options$dom = "<'row'<'col-sm-12't>><'row'<'col-sm-6'p><'col-sm-6'l>><'row'<'col-sm-12'i>>"
+  options$drawCallback <- JS('function() { 
+    if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
+      window.parent.RCloud.UI.viewer.initialiseTable();
+      $("html, body").animate({ scrollTop: 0 }, "fast");
+      $(".dataTables_paginate")[$(".dataTables_paginate a.disabled").length == $(".dataTables_paginate a").length ? "hide" : "show"]();
+    }
+  }')
   invisible(options)
 }
 
@@ -86,23 +93,16 @@ renderDataFrame <- function(varName, varValue, title) {
     if(nrow(varValue) > 0 && ncol(varValue) > 0) {
       options <- defaultEnviewerDTOptions()
       options$serverSide <- TRUE
-      options$drawCallback <- JS('function() { 
-        if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
-          $("html, body").animate({ scrollTop: 0 }, "fast");
-          $(".dataTables_paginate")[$(".dataTables_paginate a.disabled").length == $(".dataTables_paginate a").length ? "hide" : "show"]();
-        }
-      }')
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
       options$ajax <- JS(paste0('function(data, callback, settings) {
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
-        window.parent.RCloud.UI.viewer.initialiseTable();
         window.parent.RCloud.UI.viewer.updateDataSettings(data.length);
         window.parent.RCloud.UI.viewer.dataFrameCallback("', varName, '", data, callback, settings);
     }
     }'))
       data <- data.frame(matrix(ncol = ncol(varValue), nrow = 0))
       names(data) <- names(varValue)
-      x <- as.character(DT::datatable(data, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = "100%"))
+      x <- as.character(DT::datatable(data, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = '100%'))
     } else {
       x <- paste0('<div><span>Data frame "', varName, '" is empty.</span></div>')
     }
@@ -126,8 +126,7 @@ renderDataFrame <- function(varName, varValue, title) {
       stop("invalid 'varValue' argument")
     x <- as.data.frame(x)
     options <- defaultEnviewerDTOptions()
-    options$paging <- (nrow(x) > options$pageLength)
-    x <- as.character(datatable(x, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = 400))
+    x <- as.character(datatable(x, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = '100%'))
   }
   invisible(x)
 }

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -1,6 +1,6 @@
 # there doesn't seem to be a lower-level way to customize View?
 validLengths <- c(10, 20, 50, 100, 200)
-defaultLength <- 20
+defaultLength <- 50
 
 getPageSize <- function() {
   setting <- rcloud.config.get.user.option('dataframe-page-size')   

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -79,12 +79,13 @@ renderDataFrame <- function(varName, varValue, title) {
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
       options$ajax <- JS(paste0('function(data, callback, settings) {
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
+        window.parent.RCloud.UI.viewer.initialiseTable($(document));
         window.parent.RCloud.UI.viewer.dataFrameCallback("', varName, '", data, callback, settings);
     }
     }'))
       data <- data.frame(matrix(ncol = ncol(varValue), nrow = 0))
       names(data) <- names(varValue)
-      x <- as.character(DT::datatable(data, caption = title, options = options, style = 'default', width = "100%"))
+      x <- paste0('<script type="text/javascript">window.parent.RCloud.UI.viewer.initialiseTable(document);</script>', as.character(DT::datatable(data, caption = title, options = options, style = 'default', width = "100%")))
     } else {
       x <- paste0('<div><span>Data frame "', varName, '" is empty.</span></div>')
     }

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -1,16 +1,13 @@
 # there doesn't seem to be a lower-level way to customize View?
 
-ENVIEWER_PAGE_SIZE <- 20
 
 defaultEnviewerDTOptions <- function() {
   options <- list()
   options$paging <- TRUE
   options$pagingType <- "full"
-  options$lengthChange <- FALSE
   options$searching <- FALSE
-  options$info <- FALSE
   options$ordering <- FALSE
-  options$pageLength <- ENVIEWER_PAGE_SIZE
+  options$pageLength <- rcloud.config.get.user.option('dataframe-page-size') 
   options$fixedHeader = TRUE
   invisible(options)
 }
@@ -75,11 +72,12 @@ renderDataFrame <- function(varName, varValue, title) {
     if(nrow(varValue) > 0 && ncol(varValue) > 0) {
       options <- defaultEnviewerDTOptions()
       options$serverSide <- TRUE
-      options$paging <- (nrow(varValue) > ENVIEWER_PAGE_SIZE)
+      options$paging <- (nrow(varValue) > options$pageLength)
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
       options$ajax <- JS(paste0('function(data, callback, settings) {
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
         window.parent.RCloud.UI.viewer.initialiseTable();
+        window.parent.RCloud.UI.viewer.updateDataSettings(data.length);
         window.parent.RCloud.UI.viewer.dataFrameCallback("', varName, '", data, callback, settings);
     }
     }'))
@@ -109,7 +107,7 @@ renderDataFrame <- function(varName, varValue, title) {
       stop("invalid 'varValue' argument")
     x <- as.data.frame(x)
     options <- defaultEnviewerDTOptions()
-    options$paging <- (nrow(x) > ENVIEWER_PAGE_SIZE)
+    options$paging <- (nrow(x) > options$pageLength)
     x <- as.character(datatable(x, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = 400))
   }
   invisible(x)

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -1,14 +1,15 @@
 # there doesn't seem to be a lower-level way to customize View?
-validLengths <- c(10, 25, 50, 100, 200)
+validLengths <- c(10, 20, 50, 100, 200)
+defaultLength <- 20
 
 getPageSize <- function() {
   setting <- rcloud.config.get.user.option('dataframe-page-size')   
   if(is.null(setting)) {
-    25
+    defaultLength
   } else if(setting %in% validLengths) {
     setting
   } else {
-    25
+    defaultLength
   }
 }
 

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -73,6 +73,11 @@ renderDataFrame <- function(varName, varValue, title) {
       options <- defaultEnviewerDTOptions()
       options$serverSide <- TRUE
       options$paging <- (nrow(varValue) > options$pageLength)
+      options$drawCallback <- JS('function() { 
+        if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
+          $("html, body").animate({ scrollTop: 0 }, "fast");
+        }
+      }')
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
       options$ajax <- JS(paste0('function(data, callback, settings) {
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -20,12 +20,11 @@ defaultEnviewerDTOptions <- function() {
   options$searching <- FALSE
   options$ordering <- FALSE
   options$pageLength <- getPageSize()
-  options$fixedHeader = TRUE
-  options$lengthMenu = validLengths
+  options$fixedHeader <- TRUE
+  options$lengthMenu <- validLengths
   options$dom = "<'row'<'col-sm-12't>><'row'<'col-sm-6'p><'col-sm-6'l>><'row'<'col-sm-12'i>>"
   options$drawCallback <- JS('function() { 
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
-      window.parent.RCloud.UI.viewer.initialiseTable();
       $("html, body").animate({ scrollTop: 0 }, "fast");
       $(".dataTables_paginate")[$(".dataTables_paginate a.disabled").length == $(".dataTables_paginate a").length ? "hide" : "show"]();
     }
@@ -96,6 +95,7 @@ renderDataFrame <- function(varName, varValue, title) {
       # htmlwidget is displayed in an iframe, but data.frame paging OCAP is available on the parent page. 
       options$ajax <- JS(paste0('function(data, callback, settings) {
     if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
+        window.parent.RCloud.UI.viewer.initialiseTable();
         window.parent.RCloud.UI.viewer.updateDataSettings(data.length);
         window.parent.RCloud.UI.viewer.dataFrameCallback("', varName, '", data, callback, settings);
     }
@@ -126,6 +126,18 @@ renderDataFrame <- function(varName, varValue, title) {
       stop("invalid 'varValue' argument")
     x <- as.data.frame(x)
     options <- defaultEnviewerDTOptions()
+
+    options$initComplete <- JS(paste0('function() {
+    if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
+      window.parent.RCloud.UI.viewer.initialiseTable();
+      setTimeout(function() {
+          var dt = $(".dataTable:eq(0)").DataTable();
+          dt.draw();
+      }, 500);
+    }
+    }'))
+
+    # , width = '100%'
     x <- as.character(datatable(x, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = '100%'))
   }
   invisible(x)

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -11,6 +11,7 @@ defaultEnviewerDTOptions <- function() {
   options$info <- FALSE
   options$ordering <- FALSE
   options$pageLength <- ENVIEWER_PAGE_SIZE
+  options$fixedHeader = TRUE
   invisible(options)
 }
 
@@ -85,7 +86,7 @@ renderDataFrame <- function(varName, varValue, title) {
     }'))
       data <- data.frame(matrix(ncol = ncol(varValue), nrow = 0))
       names(data) <- names(varValue)
-      x <- as.character(DT::datatable(data, caption = title, options = options, style = 'default', width = "100%"))
+      x <- as.character(DT::datatable(data, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = "100%"))
     } else {
       x <- paste0('<div><span>Data frame "', varName, '" is empty.</span></div>')
     }
@@ -110,7 +111,7 @@ renderDataFrame <- function(varName, varValue, title) {
     x <- as.data.frame(x)
     options <- defaultEnviewerDTOptions()
     options$paging <- (nrow(x) > ENVIEWER_PAGE_SIZE)
-    x <- as.character(datatable(x, caption = title, options = options, style = 'default', width = 400))
+    x <- as.character(datatable(x, extensions = 'FixedHeader', caption = title, options = options, style = 'default', width = 400))
   }
   invisible(x)
 }

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -1,5 +1,16 @@
 # there doesn't seem to be a lower-level way to customize View?
+validLengths <- c(10, 25, 50, 100, 200)
 
+getPageSize <- function() {
+  setting <- rcloud.config.get.user.option('dataframe-page-size')   
+  if(is.null(setting)) {
+    25
+  } else if(setting %in% validLengths) {
+    setting
+  } else {
+    25
+  }
+}
 
 defaultEnviewerDTOptions <- function() {
   options <- list()
@@ -7,8 +18,9 @@ defaultEnviewerDTOptions <- function() {
   options$pagingType <- "full"
   options$searching <- FALSE
   options$ordering <- FALSE
-  options$pageLength <- rcloud.config.get.user.option('dataframe-page-size') 
+  options$pageLength <- getPageSize()
   options$fixedHeader = TRUE
+  options$lengthMenu = validLengths
   invisible(options)
 }
 

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -22,6 +22,7 @@ defaultEnviewerDTOptions <- function() {
   options$pageLength <- getPageSize()
   options$fixedHeader = TRUE
   options$lengthMenu = validLengths
+  options$dom = "<'row'<'col-sm-12't>><'row'<'col-sm-6'p><'col-sm-6'l>><'row'<'col-sm-12'i>>"
   invisible(options)
 }
 

--- a/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
+++ b/rcloud.packages/rcloud.viewer/R/rcloud.viewer.R
@@ -85,7 +85,6 @@ renderDataFrame <- function(varName, varValue, title) {
     if(nrow(varValue) > 0 && ncol(varValue) > 0) {
       options <- defaultEnviewerDTOptions()
       options$serverSide <- TRUE
-      options$paging <- (nrow(varValue) > options$pageLength)
       options$drawCallback <- JS('function() { 
         if(window.parent && window.parent.RCloud && window.parent.RCloud.UI && window.parent.RCloud.UI.viewer) {
           $("html, body").animate({ scrollTop: 0 }, "fast");

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -44,6 +44,17 @@ return {
               },
               initialiseTable: function() {
                 $('#viewer-body-wrapper').find('iframe').contents().find('head').append('<link rel="stylesheet" type="text/css" href="/css/rcloud.css"><link rel="stylesheet" type="text/css" href="/css/rcloud-viewer.css">');
+              },
+              updateDataSettings: function(page_size) {
+                var existing_page_size = $('#viewer-body-wrapper').data('pagesize');
+
+                if(existing_page_size && page_size != existing_page_size) {
+                    console.log('updating the page size...');
+                }
+
+                // update
+                $('#viewer-body-wrapper').data('pagesize', page_size);
+
               }
         };
         
@@ -58,10 +69,15 @@ return {
                 panel: viewer_panel
             }
         });
+
+        // $('#example').on( 'length.dt', function ( e, settings, len ) {
+        //     console.log( 'New page length: '+len );
+        // } );
+
         k();
     },
     view: function(data, title, k) {
-        $('#viewer-body-wrapper > div').remove();
+        $('#viewer-body-wrapper > div:not(.panel-fixed-header)').remove();
         $('#collapse-data-viewer').data('panel-sizer', function(panel) {
           var widgetDiv = $(panel).find('.rcloud-htmlwidget-content');
           /*
@@ -82,6 +98,7 @@ return {
           widgetDiv.data('panel-initial-height', iframe.get(0).height);
           iframe.get(0).height = '100%';
         }
+
         $('#viewer-body-wrapper').append(widgetDiv);
         RCloud.UI.right_panel.collapse($("#collapse-data-viewer"), false, false);
         k();

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -14,7 +14,6 @@ return {
         
         clear_display();
                             
-               
         RCloud.UI.viewer = {
               view_dataframe_page : ocaps.view_dataframe_page,
               dataFrameCallback : function(variable, data, callback, settings) {
@@ -29,8 +28,8 @@ return {
                             callback(dataObject);
                   }); 
               },
-              initialiseTable: function(doc) {
-                $(doc).find('body').append('<style type="text/css">body {padding:0!important;}</style>');
+              initialiseTable: function() {
+                $('#viewer-body-wrapper').find('iframe').contents().find('head').append('<link rel="stylesheet" type="text/css" href="/css/rcloud.css"><link rel="stylesheet" type="text/css" href="/css/rcloud-viewer.css">');
               }
         };
         

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -3,7 +3,21 @@
     var viewer_panel = {
         body: function() {
             return $.el.div({id: "viewer-body-wrapper", 'class': 'panel-body tight'});
-        }
+        },
+        panel_sizer: function(el) {
+            return RCloud.UI.collapsible_column.default_sizer(el);
+/*
+            if(!$('#viewer-body-wrapper').children().length) {
+                return RCloud.UI.collapsible_column.default_sizer(el);
+            } else {
+                console.log('expanding viewer to max...');
+                return {
+                    padding: RCloud.UI.collapsible_column.default_padder(el),
+                    height: 9000
+                };
+            }
+*/
+        },
     };
     function clear_display() {
         $('#viewer-body > div').remove();
@@ -50,9 +64,15 @@ return {
         $('#viewer-body-wrapper > div').remove();
         $('#collapse-data-viewer').data('panel-sizer', function(panel) {
           var widgetDiv = $(panel).find('.rcloud-htmlwidget-content');
+          /*
           var height = widgetDiv.data('panel-initial-height'); 
           var padding = RCloud.UI.collapsible_column.default_padder(panel);
           return {height: height, padding: padding};
+          */
+          return {
+              height: 9000,
+              padding: RCloud.UI.collapsible_column.default_padder(panel)
+          }
         });
         var widgetDiv = $(data);
         widgetDiv.height('100%');

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -49,7 +49,7 @@ return {
                 var existing_page_size = $('#viewer-body-wrapper').data('pagesize');
 
                 if(existing_page_size && page_size != existing_page_size) {
-                    console.log('updating the page size...');
+                    rcloud.config.set_user_option("dataframe-page-size", page_size);
                 }
 
                 // update

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -28,6 +28,9 @@ return {
                             dataObject.draw = response.draw;
                             callback(dataObject);
                   }); 
+              },
+              initialiseTable: function(doc) {
+                $(doc).find('body').append('<style type="text/css">body {padding:0!important;}</style>');
               }
         };
         

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -54,7 +54,6 @@ return {
 
                 // update
                 $('#viewer-body-wrapper').data('pagesize', page_size);
-
               }
         };
         

--- a/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
+++ b/rcloud.packages/rcloud.viewer/inst/javascript/rcloud.viewer.js
@@ -6,17 +6,6 @@
         },
         panel_sizer: function(el) {
             return RCloud.UI.collapsible_column.default_sizer(el);
-/*
-            if(!$('#viewer-body-wrapper').children().length) {
-                return RCloud.UI.collapsible_column.default_sizer(el);
-            } else {
-                console.log('expanding viewer to max...');
-                return {
-                    padding: RCloud.UI.collapsible_column.default_padder(el),
-                    height: 9000
-                };
-            }
-*/
         },
     };
     function clear_display() {
@@ -69,21 +58,12 @@ return {
             }
         });
 
-        // $('#example').on( 'length.dt', function ( e, settings, len ) {
-        //     console.log( 'New page length: '+len );
-        // } );
-
         k();
     },
     view: function(data, title, k) {
         $('#viewer-body-wrapper > div:not(.panel-fixed-header)').remove();
         $('#collapse-data-viewer').data('panel-sizer', function(panel) {
-          var widgetDiv = $(panel).find('.rcloud-htmlwidget-content');
-          /*
-          var height = widgetDiv.data('panel-initial-height'); 
-          var padding = RCloud.UI.collapsible_column.default_padder(panel);
-          return {height: height, padding: padding};
-          */
+        var widgetDiv = $(panel).find('.rcloud-htmlwidget-content');
           return {
               height: 9000,
               padding: RCloud.UI.collapsible_column.default_padder(panel)


### PR DESCRIPTION
I'm not supposing that this is 100% complete, but a review would be good if you can spare some time @gordonwoodhull.

I've removed the padding from the viewer, styled the buttons like others in RCloud, and fixed the header. Horizontal scrollbars can't be eradicated when a dataframe has lots of columns.

I was considering a dialog. If the user wishes to look at the dataframe in more detail, they could click a 'magnifying glass' icon and see the dataframe full screen.