### PR TITLE
Move the solr home to solrdata. att/rcloud.solr#86

### DIFF
--- a/conf/solr/solr.xml
+++ b/conf/solr/solr.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+   This is an example of a simple "solr.xml" file for configuring one or 
+   more Solr Cores, as well as allowing Cores to be added, removed, and 
+   reloaded via HTTP requests.
+
+   More information about options available in this configuration file, 
+   and Solr Core administration can be found online:
+   http://wiki.apache.org/solr/CoreAdmin
+-->
+
+<solr>
+
+  <solrcloud>
+
+    <str name="host">${host:}</str>
+    <int name="hostPort">${jetty.port:8983}</int>
+    <str name="hostContext">${hostContext:solr}</str>
+
+    <bool name="genericCoreNodeNames">${genericCoreNodeNames:true}</bool>
+
+    <int name="zkClientTimeout">${zkClientTimeout:30000}</int>
+    <int name="distribUpdateSoTimeout">${distribUpdateSoTimeout:600000}</int>
+    <int name="distribUpdateConnTimeout">${distribUpdateConnTimeout:60000}</int>
+    <str name="zkCredentialsProvider">${zkCredentialsProvider:org.apache.solr.common.cloud.DefaultZkCredentialsProvider}</str>
+    <str name="zkACLProvider">${zkACLProvider:org.apache.solr.common.cloud.DefaultZkACLProvider}</str>
+
+  </solrcloud>
+
+  <shardHandlerFactory name="shardHandlerFactory"
+    class="HttpShardHandlerFactory">
+    <int name="socketTimeout">${socketTimeout:600000}</int>
+    <int name="connTimeout">${connTimeout:60000}</int>
+  </shardHandlerFactory>
+
+</solr>

--- a/conf/solr/solrsetup.sh
+++ b/conf/solr/solrsetup.sh
@@ -42,20 +42,22 @@ if [ ! -e "solr-$VER" ]; then
 fi
 ln -s -f solr-$VER solr
 
+# If SOLR_HOME exists then use it
+if [ -z ${SOLR_HOME+x} ]; then
+    SOLR_DATA="${DEST}/solrdata"
+else
+    SOLR_DATA=$SOLR_HOME
+fi
 
-# Start apache Solr on default port
-echo "starting Apache Solr or default port - 8983 ... "
-"$DEST"/solr/bin/solr start
-
-SOLR_DEST="$DEST/solrdata"
-INSTANCEDIR="$SOLR_DEST/solr/rcloudnotebooks"
+INSTANCEDIR="${SOLR_DATA}/rcloudnotebooks"
 DATADIR="${INSTANCEDIR}/data"
 CONFDIR="${INSTANCEDIR}/conf"
 
 #cp -R solr/example/solr/collection1/ solr/example/solr/rcloudnotebooks
 mkdir -p $DATADIR
 mkdir -p $CONFDIR
-#rm solr/example/solr/rcloudnotebooks/core.properties
+
+cp "$WD/solr.xml" ${SOLR_DATA}/
 cp "$WD/schema.xml" ${CONFDIR}/
 cp "$WD/solrconfig.xml" ${CONFDIR}/
 cp "$WD/word-delim-types.txt" ${CONFDIR}/
@@ -66,7 +68,11 @@ cp  "$WD/stopwords.txt" ${CONFDIR}/
 cp -r "$WD/lang" ${CONFDIR}/
 # Create a collection for the RCloud Notebooks
 
- 
+# Start apache Solr on default port
+echo "starting Apache Solr or default port - 8983 ... "
+"$DEST"/solr/bin/solr start -s $SOLR_DATA
+
+
 QUERY="http://localhost:8983/solr/admin/cores?action=CREATE&name=rcloudnotebooks&instanceDir=$INSTANCEDIR&config=solrconfig.xml&schema=schema.xml&dataDir=$DATADIR"
 curl "$QUERY"
 


### PR DESCRIPTION
This relates to att/rcloud.solr#86

Main changes are:

* add `solr.xml` so that the `solrdata` directory can be used as the solr home
* update `conf/solr/solrsetup.sh` with the new path locations

Before we merge, I just wanted to check what the expected behaviour for `$SOLR_HOME` should be? I don't have that set on my machine so I need to start solr like this:

```sh
/data/rcloud/solr/solr/bin/solr start -s /data/rcloud/solr/solrdata
```

And this will survive restarts. In `solrsetup.sh` I check for `$SOLR_HOME` and will use that path if the variable has been set.