### PR TITLE
Improve notebook output autoscroll functionality

### DIFF
--- a/htdocs/js/notebook/cell_view.js
+++ b/htdocs/js/notebook/cell_view.js
@@ -30,8 +30,17 @@ function create_cell_html_view(language, cell_model) {
     var highlights_;
     var code_preprocessors_ = []; // will be an extension point, someday
     var running_state_;  // running state
-    var running_ui_state_ = {add_result: {}};
     var autoscroll_notebook_output_;
+    var results_processing_context_ = {
+      options : {
+        no_of_results_in_batch: 20,
+        notebook_update_delay : 20,
+      },
+      results : [],
+      stop : false,
+      prev_scroll : null,
+      scrolled : false
+    };
 
     // input1
     var prompt_text_;
@@ -203,12 +212,11 @@ function create_cell_html_view(language, cell_model) {
         else div.off('mousedown.rcloud-cell mouseup.rcloud-cell');
     }
 
-    // postprocessing the dom is slow, so only do this when we have a break
-    var result_updated = _.debounce(function() {
+    function result_updated() {
         Notebook.Cell.postprocessors.entries('all').forEach(function(post) {
             post.process(result_div_, result);
         });
-    }, 100);
+    }
 
     function clear_result() {
         result_div_.empty();
@@ -216,7 +224,147 @@ function create_cell_html_view(language, cell_model) {
         if(cell_controls_)
             results_button_border(false);
     }
+    
+    
+    function is_in_document() {
+      return $.contains(document, notebook_cell_div.get(0));
+    }
+    
+    function is_result_div_visible_in_cellarea() {
+        return ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, result_div_]);
+    }
+    
+    function scroll() {
+        if(!autoscroll_notebook_output_) {
+          return;
+        }
+        var cellarea = $('#rcloud-cellarea');
+        
+        if(result_div_) {
+          var opts = {
+            'axis' : 'y',
+            'duration' : 0,
+            'interrupt' : true,
+            'offset' : {top: 10},
+          };
+          ui_utils.scroll_to_after(result_div_, opts, cellarea, [notebook_cell_div], cellarea.height());
+        }
+    }
+    function consume_result(type, r)  {
+          switch(type) {
+            case 'selection':
+            case 'deferred_result':
+                break;
+            default:
+                Notebook.Cell.preprocessors.entries('all').forEach(function(pre) {
+                    r = pre.process(r);
+                });
+            }
 
+            if(type!='code')
+                current_result_ = null;
+            if(type!='error')
+                current_error_ = null;
+            var pre;
+            switch(type) {
+            case 'code':
+                if(!current_result_) {
+                    pre = $('<pre></pre>');
+                    current_result_ = $('<code></code>');
+                    pre.append(current_result_);
+                    result_div_.append(pre);
+                }
+                current_result_.append(_.escape(r));
+                break;
+            case 'error':
+                // sorry about this!
+                if(!current_error_) {
+                    pre = $('<pre></pre>');
+                    current_error_ = $('<code style="color: crimson"></code>');
+                    pre.append(current_error_);
+                    result_div_.append(pre);
+                }
+                current_error_.append(_.escape(r));
+                break;
+            case 'selection':
+            case 'html':
+                result_div_.append(r);
+                break;
+            case 'deferred_result':
+                result_div_.append('<span class="deferred-result">' + r + '</span>');
+                break;
+            default:
+                throw new Error('unknown result type ' + type);
+            }
+    }
+    
+    function should_scroll(initial_condition) {
+      return initial_condition && !is_result_div_visible_in_cellarea() && !results_processing_context_.scrolled;
+    }
+      
+    function schedule_results_consumer(delay) {
+        results_processing_context_.stop = false;
+        results_processing_context_.results.length = 0;
+        var result_consumer = function() {
+            var counter = 0;
+            var scroll_after = is_result_div_visible_in_cellarea();
+            results_processing_context_.scrolled = false;
+            while(counter < results_processing_context_.options.no_of_results_in_batch) {
+              var result = results_processing_context_.results.shift();
+              if(!result) {
+                break;
+              }
+              consume_result(result.type, result.result);
+              counter++;
+              if (should_scroll(scroll_after)) {
+                scroll();
+              }
+            }
+            result_updated();
+            
+            var wait_for_content = function(attempt, callback) {
+              var WAIT_DELAY = 3;
+              var MAX_WAIT_STEPS = 7;
+              var MAX_WAIT_DELAY = 300;
+              if(attempt <= MAX_WAIT_STEPS) {
+                if((result_div_.find('.rcloud-htmlwidget').length > 0 && result_div_.find('.rcloud-htmlwidget').find('div').is(':empty')) 
+                   || result_div_.find('.deferred-result').length > 0) {
+                  var next_attempt = attempt+1;
+                  setTimeout(wait_for_content, Math.max(WAIT_DELAY^(next_attempt), MAX_WAIT_DELAY), next_attempt, callback);
+                  return;
+                }
+              }
+              callback();
+            };
+            
+            setTimeout(wait_for_content, 0, 1, function() {
+              if (should_scroll(scroll_after)) {
+                scroll();
+              }
+              if (is_in_document() && (!results_processing_context_.stop || results_processing_context_.results.length > 0)) {
+                window.setTimeout(result_consumer, results_processing_context_.options.notebook_update_delay);
+              }
+            });
+            
+            
+        };
+        window.setTimeout(result_consumer, delay);
+    }
+    
+    function stop_results_consumer(callback) {
+      results_processing_context_.stop = true;
+      var wait = function() {
+        if(is_in_document()) {
+          if(results_processing_context_.results.length > 0) {
+            setTimeout(wait, results_processing_context_.options.notebook_update_delay);
+          } else {
+            callback();
+          }
+        }
+      };
+      wait();
+    }
+    
     // start trying to refactor out this repetitive nonsense
     function ace_stuff(div, content) {
         ace.require("ace/ext/language_tools");
@@ -720,56 +868,15 @@ function create_cell_html_view(language, cell_model) {
                 if(RCloud.language.is_a_markdown(language))
                     result.hide_source(true);
                 has_result_ = true;
+                schedule_results_consumer(results_processing_context_.options.notebook_update_delay);
             }
-            running_ui_state_.add_result.result_div_visible_in_cellarea = this.is_result_div_visible_in_cellarea();
             this.toggle_results(true); // always show when updating
-            switch(type) {
-            case 'selection':
-            case 'deferred_result':
-                break;
-            default:
-                Notebook.Cell.preprocessors.entries('all').forEach(function(pre) {
-                    r = pre.process(r);
-                });
-            }
+            
+            results_processing_context_.results.push({
+              type : type,
+              result : r
+            });
 
-            if(type!='code')
-                current_result_ = null;
-            if(type!='error')
-                current_error_ = null;
-            var pre;
-            switch(type) {
-            case 'code':
-                if(!current_result_) {
-                    pre = $('<pre></pre>');
-                    current_result_ = $('<code></code>');
-                    pre.append(current_result_);
-                    result_div_.append(pre);
-                }
-                current_result_.append(_.escape(r));
-                break;
-            case 'error':
-                // sorry about this!
-                if(!current_error_) {
-                    pre = $('<pre></pre>');
-                    current_error_ = $('<code style="color: crimson"></code>');
-                    pre.append(current_error_);
-                    result_div_.append(pre);
-                }
-                current_error_.append(_.escape(r));
-                break;
-            case 'selection':
-            case 'html':
-                result_div_.append(r);
-                break;
-            case 'deferred_result':
-                result_div_.append('<span class="deferred-result">' + r + '</span>');
-                break;
-            default:
-                throw new Error('unknown result type ' + type);
-            }
-            this.scroll_to_result(running_ui_state_.add_result);
-            result_updated();
         },
         end_output: function(error) {
             if(!has_result_) {
@@ -777,9 +884,12 @@ function create_cell_html_view(language, cell_model) {
                 result_div_.empty();
                 has_result_ = true;
             }
-            this.state_changed(error ? 'error' : running_state_==='unknown-running' ? 'unknown' : 'complete');
-            current_result_ = current_error_ = null;
-            this.scroll_to_result(running_ui_state_.add_result);
+            var that = this;
+            stop_results_consumer(function() {
+              that.state_changed(error ? 'error' : running_state_==='unknown-running' ? 'unknown' : 'complete');
+              current_result_ = current_error_ = null;
+            });
+            
         },
         clear_result: clear_result,
         set_readonly: function(readonly) {
@@ -800,6 +910,12 @@ function create_cell_html_view(language, cell_model) {
         },
         set_autoscroll_notebook_output: function(whether) {
             autoscroll_notebook_output_ = whether;
+        },
+        on_scroll : function(event) {
+          if(results_processing_context_.prev_scroll) {
+            results_processing_context_.scrolled = (results_processing_context_.prev_scroll > event.currentTarget.scrollTop);
+          }
+          results_processing_context_.prev_scroll = event.currentTarget.scrollTop;
         },
         click_to_edit: click_to_edit,
 
@@ -936,25 +1052,6 @@ function create_cell_html_view(language, cell_model) {
                 source_div_.show();
                 edit_button_border(true);
             }
-        },
-        is_result_div_visible_in_cellarea: function() {
-            return ui_utils.is_visible_in_scrollable($('#rcloud-cellarea'), [notebook_cell_div, result_div_]);
-        },
-        scroll_to_result: function(previous_state) {
-            var that = this;
-            var shouldScroll = false;
-            if(previous_state) {
-              shouldScroll = previous_state.result_div_visible_in_cellarea && !that.is_result_div_visible_in_cellarea();
-            }
-            
-            shouldScroll = shouldScroll && autoscroll_notebook_output_;
-            
-            ui_utils.on_next_tick(function() {
-                var cellarea = $('#rcloud-cellarea');
-                if(result_div_ && shouldScroll) {
-                  ui_utils.scroll_to_after(result_div_, undefined, cellarea, [notebook_cell_div], cellarea.height());
-                }
-            });
         },
         toggle_results: function(val) {
             if(val===undefined)

--- a/htdocs/js/notebook/notebook_view.js
+++ b/htdocs/js/notebook/notebook_view.js
@@ -82,6 +82,7 @@ Notebook.create_html_view = function(model, root_div)
             _.each(this.sub_views, function(view) {
                 view.set_autoscroll_notebook_output(whether);
             });
+            
         },
         update_urls: function() {
             RCloud.UI.scratchpad.update_asset_url();
@@ -95,8 +96,17 @@ Notebook.create_html_view = function(model, root_div)
             _.each(this.sub_views, function(view) {
                 view.reformat();
             });
+        },
+        on_scroll: function(event) {
+          if(autoscroll_notebook_output_) {
+              _.each(this.sub_views, function(view) {
+                view.on_scroll(event);
+              });
+          }
         }
     };
     model.views.push(result);
+    
+    $('#rcloud-cellarea').on('scroll', function(event) { result.on_scroll(event); });
     return result;
 };

--- a/htdocs/js/ui_utils.js
+++ b/htdocs/js/ui_utils.js
@@ -617,23 +617,21 @@ ui_utils.on_next_tick = function(f) {
     window.setTimeout(f, 0);
 };
 
-ui_utils.scroll_to_after = function($sel, duration, $scroller, $offset_elements, scroll_top_offset) {
+ui_utils.scroll_to_after = function($sel, scroll_opts, $scroller, $offset_elements, scroll_top_offset) {
     // no idea why the plugin doesn't take current scroll into account when using
     // the element parameter version
+    var opts = $.extend($.scrollTo.defaults, {'axis':'y'}, scroll_opts);
     if ($sel.length === 0)
         return;
-    var opts;
     if(!scroll_top_offset) {
       scroll_top_offset = 0;
     }
-    if(duration !== undefined)
-        opts = {animation: {duration: duration}};
     if(!$scroller) {
       $scroller = $sel.parent();
     }
     var elemtoppos = ui_utils.get_top_offset($offset_elements);
     var y = $scroller.scrollTop() + elemtoppos + $sel.position().top + $sel.outerHeight() - scroll_top_offset;
-    $scroller.scrollTo(null, y, opts);
+    $scroller.scrollTo(y, opts);
 };
 
 ui_utils.get_top_offset = function($offset_elements) {
@@ -662,16 +660,21 @@ ui_utils.scroll_into_view = function($scroller, top_buffer, bottom_buffer, on_co
         console.warn('scroll_into_view needs offset elements');
         return;
     }
+    var opts = $.extend($.scrollTo.defaults, { 'axis':'y', 'duration':600 });
     var height = +$scroller.css("height").replace("px","");
-    var scrolltop = $scroller.scrollTop(),
-        options = on_complete ? { animation: { complete : on_complete }} : {};
+    var scrolltop = $scroller.scrollTop();
+    if(on_complete) {
+      opts.onAfter = function(target, settings) {
+        on_complete();
+      }
+    }
 
     var elemtop = ui_utils.get_top_offset(Array.prototype.slice.call(arguments, 4));
 
     if(elemtop > height)
-        $scroller.scrollTo(null, scrolltop + elemtop - height + top_buffer, options);
+        $scroller.scrollTo( scrolltop + elemtop - height + top_buffer, opts);
     else if(elemtop < 0)
-        $scroller.scrollTo(null, scrolltop + elemtop - bottom_buffer, options);
+        $scroller.scrollTo( scrolltop + elemtop - bottom_buffer, opts);
     else {
         // no scrolling, so automatically call on_complete if it's defined:
         if(on_complete) {

--- a/htdocs/lib/js/jquery.scrollto.js
+++ b/htdocs/lib/js/jquery.scrollto.js
@@ -1,34 +1,210 @@
 /*!
- * jquery.scrollto.js 0.0.1 - https://github.com/yckart/jquery.scrollto.js
- * Scroll smooth to any element in your DOM.
- *
- * Copyright (c) 2012 Yannick Albert (http://yckart.com)
- * Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php).
- * 2013/02/17
- **/
-(function ($) {
-    $.scrollTo = $.fn.scrollTo = function(x, y, options){
-        if (!(this instanceof $)) return $.fn.scrollTo.apply($('html, body'), arguments);
+ * jQuery.scrollTo
+ * Copyright (c) 2007-2015 Ariel Flesler - aflesler<a>gmail<d>com | http://flesler.blogspot.com
+ * Licensed under MIT
+ * http://flesler.blogspot.com/2007/10/jqueryscrollto.html
+ * @projectDescription Lightweight, cross-browser and highly customizable animated scrolling with jQuery
+ * @author Ariel Flesler
+ * @version 2.1.2
+ */
+;(function(factory) {
+	'use strict';
+	if (typeof define === 'function' && define.amd) {
+		// AMD
+		define(['jquery'], factory);
+	} else if (typeof module !== 'undefined' && module.exports) {
+		// CommonJS
+		module.exports = factory(require('jquery'));
+	} else {
+		// Global
+		factory(jQuery);
+	}
+})(function($) {
+	'use strict';
 
-        options = $.extend({}, {
-            gap: {
-                x: 0,
-                y: 0
-            },
-            animation: {
-                easing: 'swing',
-                duration: 600,
-                complete: $.noop,
-                step: $.noop
-            }
-        }, options);
+	var $scrollTo = $.scrollTo = function(target, duration, settings) {
+		return $(window).scrollTo(target, duration, settings);
+	};
 
-        return this.each(function(){
-            var elem = $(this);
-            elem.stop().animate({
-                scrollLeft: !isNaN(Number(x)) ? x : $(x).offset().left + options.gap.x,
-                scrollTop: !isNaN(Number(y)) ? y : $(y).offset().top + options.gap.y
-            }, options.animation);
-        });
-    };
-})(jQuery);
+	$scrollTo.defaults = {
+		axis:'xy',
+		duration: 0,
+		limit:true
+	};
+
+	function isWin(elem) {
+		return !elem.nodeName ||
+			$.inArray(elem.nodeName.toLowerCase(), ['iframe','#document','html','body']) !== -1;
+	}		
+
+	$.fn.scrollTo = function(target, duration, settings) {
+		if (typeof duration === 'object') {
+			settings = duration;
+			duration = 0;
+		}
+		if (typeof settings === 'function') {
+			settings = { onAfter:settings };
+		}
+		if (target === 'max') {
+			target = 9e9;
+		}
+
+		settings = $.extend({}, $scrollTo.defaults, settings);
+		// Speed is still recognized for backwards compatibility
+		duration = duration || settings.duration;
+		// Make sure the settings are given right
+		var queue = settings.queue && settings.axis.length > 1;
+		if (queue) {
+			// Let's keep the overall duration
+			duration /= 2;
+		}
+		settings.offset = both(settings.offset);
+		settings.over = both(settings.over);
+
+		return this.each(function() {
+			// Null target yields nothing, just like jQuery does
+			if (target === null) return;
+
+			var win = isWin(this),
+				elem = win ? this.contentWindow || window : this,
+				$elem = $(elem),
+				targ = target, 
+				attr = {},
+				toff;
+
+			switch (typeof targ) {
+				// A number will pass the regex
+				case 'number':
+				case 'string':
+					if (/^([+-]=?)?\d+(\.\d+)?(px|%)?$/.test(targ)) {
+						targ = both(targ);
+						// We are done
+						break;
+					}
+					// Relative/Absolute selector
+					targ = win ? $(targ) : $(targ, elem);
+					/* falls through */
+				case 'object':
+					if (targ.length === 0) return;
+					// DOMElement / jQuery
+					if (targ.is || targ.style) {
+						// Get the real position of the target
+						toff = (targ = $(targ)).offset();
+					}
+			}
+
+			var offset = $.isFunction(settings.offset) && settings.offset(elem, targ) || settings.offset;
+
+			$.each(settings.axis.split(''), function(i, axis) {
+				var Pos	= axis === 'x' ? 'Left' : 'Top',
+					pos = Pos.toLowerCase(),
+					key = 'scroll' + Pos,
+					prev = $elem[key](),
+					max = $scrollTo.max(elem, axis);
+
+				if (toff) {// jQuery / DOMElement
+					attr[key] = toff[pos] + (win ? 0 : prev - $elem.offset()[pos]);
+
+					// If it's a dom element, reduce the margin
+					if (settings.margin) {
+						attr[key] -= parseInt(targ.css('margin'+Pos), 10) || 0;
+						attr[key] -= parseInt(targ.css('border'+Pos+'Width'), 10) || 0;
+					}
+
+					attr[key] += offset[pos] || 0;
+
+					if (settings.over[pos]) {
+						// Scroll to a fraction of its width/height
+						attr[key] += targ[axis === 'x'?'width':'height']() * settings.over[pos];
+					}
+				} else {
+					var val = targ[pos];
+					// Handle percentage values
+					attr[key] = val.slice && val.slice(-1) === '%' ?
+						parseFloat(val) / 100 * max
+						: val;
+				}
+
+				// Number or 'number'
+				if (settings.limit && /^\d+$/.test(attr[key])) {
+					// Check the limits
+					attr[key] = attr[key] <= 0 ? 0 : Math.min(attr[key], max);
+				}
+
+				// Don't waste time animating, if there's no need.
+				if (!i && settings.axis.length > 1) {
+					if (prev === attr[key]) {
+						// No animation needed
+						attr = {};
+					} else if (queue) {
+						// Intermediate animation
+						animate(settings.onAfterFirst);
+						// Don't animate this axis again in the next iteration.
+						attr = {};
+					}
+				}
+			});
+
+			animate(settings.onAfter);
+
+			function animate(callback) {
+				var opts = $.extend({}, settings, {
+					// The queue setting conflicts with animate()
+					// Force it to always be true
+					queue: true,
+					duration: duration,
+					complete: callback && function() {
+						callback.call(elem, targ, settings);
+					}
+				});
+				$elem.animate(attr, opts);
+			}
+		});
+	};
+
+	// Max scrolling position, works on quirks mode
+	// It only fails (not too badly) on IE, quirks mode.
+	$scrollTo.max = function(elem, axis) {
+		var Dim = axis === 'x' ? 'Width' : 'Height',
+			scroll = 'scroll'+Dim;
+
+		if (!isWin(elem))
+			return elem[scroll] - $(elem)[Dim.toLowerCase()]();
+
+		var size = 'client' + Dim,
+			doc = elem.ownerDocument || elem.document,
+			html = doc.documentElement,
+			body = doc.body;
+
+		return Math.max(html[scroll], body[scroll]) - Math.min(html[size], body[size]);
+	};
+
+	function both(val) {
+		return $.isFunction(val) || $.isPlainObject(val) ? val : { top:val, left:val };
+	}
+
+	// Add special hooks so that window scroll properties can be animated
+	$.Tween.propHooks.scrollLeft = 
+	$.Tween.propHooks.scrollTop = {
+		get: function(t) {
+			return $(t.elem)[t.prop]();
+		},
+		set: function(t) {
+			var curr = this.get(t);
+			// If interrupt is true and user scrolled, stop animating
+			if (t.options.interrupt && t._last && t._last !== curr) {
+				return $(t.elem).stop();
+			}
+			var next = Math.round(t.now);
+			// Don't waste CPU
+			// Browsers don't render floating point scroll
+			if (curr !== next) {
+				$(t.elem)[t.prop](next);
+				t._last = this.get(t);
+			}
+		}
+	};
+
+	// AMD requirement
+	return $scrollTo;
+});


### PR DESCRIPTION
Introduce results buffering and process the results in batches. This removes fleakyness which was caused by race conditions between: R producing the results and pushing htmlwidgets contents, autoscroll feature and user scroll actions.

Thanks to this only scrolls up the notebook cell area need to be detected and considered as a trigger for disabling autoscroll.

The jquery.scrollto library got updated to alternative implementation which is actively maintained, accepts more parameters and exposes an option to stop the scrolling animation on user scroll.

FIX #2522, #2551

This change needs to be applied together with: https://github.com/att/rcloud.htmlwidgets/pull/24

Tested with various use cases, like:
```
for(i in 1:300) {
    print(1:1)
    Sys.sleep(0.001);
} 
```
```
require(DT)
for(i in 1:100) {
    print(1:1)
    if((i %% 10) == 0) {
        stocks <- data.frame(
              time = as.Date('2009-01-01') + 0:104,
              X = rnorm(105, 0, 1),
              Y = rnorm(105, 0, 2),
              Z = rnorm(105, 0, 4))
            
        print(datatable(stocks))
        
    }
    Sys.sleep(0.1);
} 
```

I tested the deferred results using the following script
```
for(i in 1:10) {
    print(1:1)
    print(wplot(1:10, 1:10))
} 
```
this was the only function that I found to provoke this type of results, I guess this is mainly used when computation separation is turned on? @gordonwoodhull if you can provide me with some examples that  use deferred results and that I could run in my dev environment I am happy to test the changes in this PR against them.