### PR TITLE
Introduce rcloud.jupyter package

### DIFF
--- a/htdocs/lib/js/ace/mode-python.js
+++ b/htdocs/lib/js/ace/mode-python.js
@@ -198,7 +198,7 @@ var PythonCompletions = function() {
           var line = session.getLine(pos.row);
           var prefix = util.retrievePrecedingIdentifier(line, pos.column);
           if(!prefix) {
-            callback(null, null);
+            callback(null, []);
             return;
           }
           rcloud.get_completions('Python', session.getValue(),

--- a/rcloud.packages/rcloud.jupyter/DESCRIPTION
+++ b/rcloud.packages/rcloud.jupyter/DESCRIPTION
@@ -1,0 +1,9 @@
+Package: rcloud.jupyter
+Title: Jupyter API Integration
+Version: 0.0.1
+Author: Carlos Scheidegger <cscheid@cscheid.net>, Mateusz Rogalski <useless5771@gmail.com>
+Maintainer: Gordon Woodhull <gordon@research.att.com>
+Description: Adds support for Jupyter kernels to RCloud
+Imports: knitr, markdown
+Suggests: reticulate, jsonlite
+License: MIT

--- a/rcloud.packages/rcloud.jupyter/NAMESPACE
+++ b/rcloud.packages/rcloud.jupyter/NAMESPACE
@@ -1,0 +1,1 @@
+export(rcloud.language.support)

--- a/rcloud.packages/rcloud.jupyter/R/main.R
+++ b/rcloud.packages/rcloud.jupyter/R/main.R
@@ -1,0 +1,186 @@
+#' 
+#' Configuration
+#' 
+#' Python version and library path are defined by the following settings from rcloud.conf:
+#'  * rcloud.jupyter.python.path - path to Python installation that should be used
+#'  * rcloud.jupyter.python.extra.libs - additional Python lib directories (e.g. where Jupyter Python modules got installed)
+#'  
+#' IMPORTANT!!! These two do not affect kernels being used, kernels are configured by kernel descriptors.
+#'  
+#'  For Jupyter configuration options see https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html
+#'  
+#' Kernels are loaded from the following default locations, if JUPYTER_PATH is not set:
+#' * "/home/<USER_NAME>/.local/share/jupyter/kernels"
+#' * "/usr/local/share/jupyter/kernels"
+#' * "/usr/share/jupyter/kernels"
+#'  
+PYTHON_PATH <- 'rcloud.jupyter.python.path'
+PYTHON_EXTRA_LIBS <- 'rcloud.jupyter.python.extra.libs'
+JUPYTER_CELL_TIMEOUT <- 'rcloud.jupyter.cell.timeout'
+
+.set_python_kernel <- function(python_kernel) {
+  session <- rcloud.support:::.session
+  session$python_kernel <- python_kernel
+}
+
+.get_python_kernel <- function() {
+  if('python_kernel' %in% names(rcloud.support:::.session)) {
+    session <- rcloud.support:::.session
+    session$python_kernel
+  } else {
+    'python'
+  }
+}
+
+#'
+#' @returnt time in seconds
+#' 
+.get_cell_timeout <- function() {
+  if (rcloud.support:::hasConf(JUPYTER_CELL_TIMEOUT)) {
+    as.integer(rcloud.support:::getConf(JUPYTER_CELL_TIMEOUT))
+  } else {
+    as.integer(600)
+  }
+}
+
+.build_init_script <- function(rcloud.session) {
+  retina <- ''  
+  if (rcloud.session$device.pixel.ratio > 1) {
+    retina <- "config InlineBackend.figure_format = 'retina'"
+  }
+  
+  inline_plots <- "%matplotlib inline"
+  paste0(retina, '\n', inline_plots)
+}
+
+#'
+#' Initializes Jupyter Adapter and stores reference to it in session with 'jupyter.adapter' key.
+#'
+.start.jupyter.adapter <- function(rcloud.session)
+{
+  require(reticulate, quietly=TRUE)
+  if (rcloud.support:::hasConf(PYTHON_PATH))
+    use_python(rcloud.support:::getConf(PYTHON_PATH))
+  sys <- import("sys")
+  ## append any admin-specified paths (as ":" - separated paths)
+  if (rcloud.support:::nzConf(PYTHON_EXTRA_LIBS)) {
+    extraLibs <- unlist(strsplit(rcloud.support:::getConf(PYTHON_EXTRA_LIBS), ':'))
+    sys$path <-c(sys$path, extraLibs)
+  }
+  sys$path <- c(sys$path, system.file("jupyter", package="rcloud.jupyter"))
+  
+  jupyter_adapter <- import("jupyter_adapter")
+  
+  runner <- jupyter_adapter$JupyterAdapter(
+                                           cell_exec_timeout = .get_cell_timeout(),
+                                           rcloud_python_init_script=.build_init_script(rcloud.session),
+                                           console_in = .console.in.handler, 
+                                           kernel_name = .get_python_kernel()
+                                           )
+  rcloud.session$jupyter.adapter <- runner
+  
+  f <- .GlobalEnv$.Rserve.done
+  
+  .GlobalEnv$.Rserve.done <- function(...) { 
+    .stop.jupyter.adapter(rcloud.session); 
+    if (is.function(f)) 
+      f(...) 
+    }
+}
+
+#'
+#' callback handler invoked when stdin input is requested from Python
+#'
+.console.in.handler <- function(prompt ) {
+  readline( prompt )
+}
+
+.stop.jupyter.adapter <- function(rcloud.session) {
+  if (!is.null(rcloud.session$jupyter.adapter)) {
+    rcloud.session$jupyter.adapter$shutdown()
+    rcloud.session$jupyter.adapter <- NULL
+    ## force GC so R side holds no reference
+    invisible(gc())
+  }
+}
+
+.exec.with.jupyter <- function(cmd, rcloud.session)
+{
+  mime_order <- c("html", "png", "jpeg", "text", "json") # richest representation to poorest [order is debatable!]
+  to.chunk <- function(chunk) {
+    # Handler to convert a chunk of response from Python engine to html to send via oob
+    found_mimes = names(chunk)
+    # Pick first format one in mime_order: hard-coded list; no SVG, no latex/mathjax
+    t = mime_order[mime_order %in% found_mimes][1] # First match in mime_order
+    if (t %in% c("html", "text"))
+      return(c(t, chunk[[t]]))  # we assume text is 'html-escaped and within <pre></pre>'
+    if (t %in% c("png", "jpeg")) {
+      img_data <- paste0("data:image/", t, ";base64,", sub("\\s+$", "", chunk[[t]]))
+      return(c(t, paste0("<img src=\"",  img_data, "\">\n")))
+    }
+    if (t %in% c("json"))
+      return(c(t, paste0('<pre>', jsonlite:::toJSON(chunk[[t]]), '</pre>')))
+  }
+  outputs <- tryCatch({
+    rcloud.session$jupyter.adapter$run_cmd(cmd)
+  }, error=function(e) {
+    msg <- e$message
+    rcloud.html.out(msg)
+    return()
+  })
+  
+  if(is.null(outputs)) {
+    return()
+  }
+  lapply(outputs, function(outval) 
+  {
+    outType <- outval$output_type
+    res <- to.chunk(outval)
+    if ( (res[1] == "text") && (outType == "CONSOLE") ) {
+      rcloud.out(res[2])
+    } else {
+      rcloud.html.out(res[2])
+      if(outType %in% c("error"))
+        return(structure(list(error="Python evaluation error"), class='cell-eval-error'))
+    }
+  })
+}
+
+rcloud.jupyter.list.kernel.specs <- function(rcloud.session)
+{
+  if (is.null(rcloud.session$jupyter.adapter))
+    .start.jupyter.adapter(rcloud.session)
+  return(rcloud.session$jupyter.adapter$get_kernel_specs())
+}
+
+.run.cell.with.jupyter <- function(command, silent, rcloud.session, ...) {
+ if (is.null(rcloud.session$jupyter.adapter))
+      .start.jupyter.adapter(rcloud.session)
+  .exec.with.jupyter(command, rcloud.session)
+}
+
+.complete.with.jupyter <- function(text, pos, thissession) {
+  if (is.null(thissession$jupyter.adapter))
+    .start.jupyter.adapter(thissession)
+  completions <- thissession$jupyter.adapter$complete(.get_python_kernel(), text, pos)
+  res <- list()
+  if(is.null(completions)) {
+    return(res)
+  }
+  res$values <- completions$matches
+  res$prefix <- substr(text, completions$cursor_start, completions$cursor_end)
+  res$position <- completions$cursor_end
+  return(res)
+}
+
+rcloud.language.support <- function()
+{
+  list(language="Python",
+       run.cell=.run.cell.with.jupyter,
+       complete=.complete.with.jupyter,
+       ace.mode="ace/mode/python",
+       hljs.class="py",
+       extension="py",
+       setup=function(rcloud.session) {},
+       teardown=function(rcloud.session) {})
+}

--- a/rcloud.packages/rcloud.jupyter/README.md
+++ b/rcloud.packages/rcloud.jupyter/README.md
@@ -1,0 +1,163 @@
+# RCloud Jupyter Package
+
+`rcloud.jupyter` package introduces support for Python (so far) via Jupyter Notebooks API
+
+> rcloud.jupyter and rcloud.python packages are incompatible and should not be loaded into RCloud at the same time.
+
+# Configuration
+
+## Jupyter Installation
+
+RCloud integrates with a single Jupyter backend, depending on which Python version it integrates with, run one of the following commands:
+
+### Python 2
+
+```{bash}
+sudo python -m pip install jupyter
+```
+
+### Python 3
+
+```{bash}
+sudo python3 -m pip3 install jupyter
+```
+
+### RCloud Configuration
+
+RCloud Jupyter package uses these settings from `rcloud.conf`:
+
+ * rcloud.jupyter.python.path - path to Python installation that should be used (e.g. `/usr/bin/python3`)
+ * rcloud.jupyter.python.extra.libs - additional Python lib directories (e.g. where Jupyter Python modules got installed)
+
+To enable `rcloud.jupyter` add it to `rcloud.languages` setting in `rcloud.conf` AND remove `rcloud.python` if it is listed there.
+
+After (re-)starting RCloud, Python integration via Jupyter should work, if it isn't, please read on.
+
+
+## Python Kernels
+
+If no kernels are configured, Jupyter will create a runtime Python kernel using the same version of Python that Jupyter uses. However if location of Python modules is not standard and/or some of the dependencies have been installed under user-specific location (e.g. `/home/[USER_NAME]/.local/lib/python3.5/site-packages`), then Jupyther will fail to start up such kernel and kernel will need to be explicitly configured (see sections below).
+
+
+
+### Python 2 kernel
+
+To register Python 2 kernel run the following command:
+
+```{bash}
+python -m ipykernel install --user
+```
+
+### Python 3 kernel
+
+To register Python 3 kernel run the following command:
+
+```{bash}
+python3 -m ipykernel install --user
+```
+
+### Configure PYTHONPATH
+
+In rare occasions when Python modules are installed in non-standard locations, kernel configuration generated in previous steps will need to be updated so `PYTHONPATH` is correct. The following example shows python3 kernel specification with extra PYTHONPATH locations which hold ipython dependencies:
+
+```{json}
+
+{
+ "argv": ["/usr/bin/python3", "-m", "ipykernel_launcher",
+          "-f", "{connection_file}"],
+ "display_name": "Python 3",
+ "language": "python",
+ "env": {
+    "PYTHONPATH" : "${PYTHONPATH}:/home/vagrant/.local/lib/python3.5/site-packages:/usr/local/lib/python3.5/dist-packages"
+  }
+}
+
+```
+
+## Runtime Settings
+
+### Listing Kernels
+
+To get a list of registered kernels run this R command in RCloud notebook:
+```{R}
+rcloud.jupyter:::rcloud.jupyter.list.kernel.specs(rcloud.support:::.session) 
+```
+Example output:
+```{R}
+$python2
+$python2$resource_dir
+[1] "/home/vagrant/.local/share/jupyter/kernels/python2"
+
+$python2$spec
+$python2$spec$env
+named list()
+
+$python2$spec$display_name
+[1] "Python 2"
+
+$python2$spec$metadata
+named list()
+
+$python2$spec$language
+[1] "python"
+
+$python2$spec$interrupt_mode
+[1] "signal"
+
+$python2$spec$argv
+[1] "/usr/bin/python"    "-m"                 "ipykernel_launcher"
+[4] "-f"                 "{connection_file}"
+
+
+
+$python3
+$python3$resource_dir
+[1] "/usr/share/jupyter/kernels/python3"
+
+$python3$spec
+$python3$spec$env
+$python3$spec$env$PYTHONPATH
+[1] "${PYTHONPATH}:/home/vagrant/.local/lib/python3.5/site-packages:/usr/local/lib/python3.5/dist-packages"
+
+
+$python3$spec$display_name
+[1] "Python 3"
+
+$python3$spec$metadata
+named list()
+
+$python3$spec$language
+[1] "python"
+
+$python3$spec$interrupt_mode
+[1] "signal"
+
+$python3$spec$argv
+[1] "/usr/bin/python3"   "-m"                 "ipykernel_launcher"
+[4] "-f"                 "{connection_file}"
+
+
+```
+
+
+### Specifying Python Kernel for Notebook
+
+RCloud by default uses `python` kernel to invoke Python cells. In setups where there are multiple python kernels available (e.g. Python 2 and Python 3) Jupyter will use a kernel with the same version of Python as Jupyter uses.
+
+To specify the kernel version that should be used to invoke Python cells in a notebook, add an R cell to RCloud notebook before all Python cells that sets specific kernel name that should be used:
+```{R}
+rcloud.jupyter:::.set_python_kernel('python2')
+```
+> Note.
+> 'kernel name' is the key of the kernel in the list of kernels returned by the 'rcloud.jupyter.list.kernel.specs' function.
+
+
+> Note. 
+> If you want to change python kernel after running some Python cells, you will need to refresh RCloud Session, for the above command to take an effect.
+
+
+# Additional Information
+
+Please refer to [Jupyter](https://jupyter.readthedocs.io/en/latest/content-quickstart.html) for more information about configuration of Jupyter and kernels.
+
+

--- a/rcloud.packages/rcloud.jupyter/inst/jupyter/RCloud_ansi2html.py
+++ b/rcloud.packages/rcloud.jupyter/inst/jupyter/RCloud_ansi2html.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# From https://raw.githubusercontent.com/Kronuz/ansi2html/master/ansi2html.py -- MIT License (obtained Oct 2014, #SSI)
+
+from __future__ import print_function
+
+import re
+_ANSI2HTML_STYLES = {}
+ANSI2HTML_CODES_RE = re.compile('(?:\033\\[(\d+(?:;\d+)*)?([cnRhlABCDfsurgKJipm]))')
+ANSI2HTML_PALETTE = {
+    # See http://ethanschoonover.com/solarized
+    'solarized': ['#073642', '#D30102', '#859900', '#B58900', '#268BD2', '#D33682', '#2AA198', '#EEE8D5', '#002B36', '#CB4B16', '#586E75', '#657B83', '#839496', '#6C71C4', '#93A1A1', '#FDF6E3'],
+    # Above mapped onto the xterm 256 color palette
+    'solarized-xterm': ['#262626', '#AF0000', '#5F8700', '#AF8700', '#0087FF', '#AF005F', '#00AFAF', '#E4E4E4', '#1C1C1C', '#D75F00', '#585858', '#626262', '#808080', '#5F5FAF', '#8A8A8A', '#FFFFD7'],
+    # Gnome default:
+    'tango': ['#000000', '#CC0000', '#4E9A06', '#C4A000', '#3465A4', '#75507B', '#06989A', '#D3D7CF', '#555753', '#EF2929', '#8AE234', '#FCE94F', '#729FCF', '#AD7FA8', '#34E2E2', '#EEEEEC'],
+    # xterm:
+    'xterm': ['#000000', '#CD0000', '#00CD00', '#CDCD00', '#0000EE', '#CD00CD', '#00CDCD', '#E5E5E5', '#7F7F7F', '#FF0000', '#00FF00', '#FFFF00', '#5C5CFF', '#FF00FF', '#00FFFF', '#FFFFFF'],
+    'console': ['#000000', '#AA0000', '#00AA00', '#AA5500', '#0000AA', '#AA00AA', '#00AAAA', '#AAAAAA', '#555555', '#FF5555', '#55FF55', '#FFFF55', '#5555FF', '#FF55FF', '#55FFFF', '#FFFFFF'],
+}
+
+
+def _ansi2html_get_styles(palette):
+    if palette not in _ANSI2HTML_STYLES:
+        p = ANSI2HTML_PALETTE.get(palette, ANSI2HTML_PALETTE['console'])
+
+        regular_style = {
+            '1': '',  # bold
+            '2': 'opacity:0.5',
+            '4': 'text-decoration:underline',
+            '5': 'font-weight:bold',
+            '7': '',
+            '8': 'display:none',
+        }
+        bold_style = regular_style.copy()
+        for i in range(8):
+            regular_style['3%s' % i] = 'color:%s' % p[i]
+            regular_style['4%s' % i] = 'background-color:%s' % p[i]
+
+            bold_style['3%s' % i] = 'color:%s' % p[i + 8]
+            bold_style['4%s' % i] = 'background-color:%s' % p[i + 8]
+
+        # The default xterm 256 colour p:
+        indexed_style = {}
+        for i in range(16):
+            indexed_style['%s' % i] = p[i]
+
+        for rr in range(6):
+            for gg in range(6):
+                for bb in range(6):
+                    i = 16 + rr * 36 + gg * 6 + bb
+                    r = (rr * 40 + 55) if rr else 0
+                    g = (gg * 40 + 55) if gg else 0
+                    b = (bb * 40 + 55) if bb else 0
+                    indexed_style['%s' % i] = ''.join('%02X' % c if 0 <= c <= 255 else None for c in (r, g, b))
+
+        for g in range(24):
+            i = g + 232
+            l = g * 10 + 8
+            indexed_style['%s' % i] = ''.join('%02X' % c if 0 <= c <= 255 else None for c in (l, l, l))
+
+        _ANSI2HTML_STYLES[palette] = (regular_style, bold_style, indexed_style)
+    return _ANSI2HTML_STYLES[palette]
+
+
+def ansi2html(text, palette='solarized'):
+    def _ansi2html(m):
+        if m.group(2) != 'm':
+            return ''
+        import sys
+        state = None
+        sub = ''
+        cs = m.group(1)
+        cs = cs.strip() if cs else ''
+        for c in cs.split(';'):
+            c = c.strip().lstrip('0') or '0'
+            if c == '0':
+                while stack:
+                    sub += '</span>'
+                    stack.pop()
+            elif c in ('38', '48'):
+                extra = [c]
+                state = 'extra'
+            elif state == 'extra':
+                if c == '5':
+                    state = 'idx'
+                elif c == '2':
+                    state = 'r'
+            elif state:
+                if state == 'idx':
+                    extra.append(c)
+                    state = None
+                    # 256 colors
+                    color = indexed_style.get(c)  # TODO: convert index to RGB!
+                    if color is not None:
+                        sub += '<span style="%s:%s">' % ('color' if extra[0] == '38' else 'background-color', color)
+                        stack.append(extra)
+                elif state in ('r', 'g', 'b'):
+                    extra.append(c)
+                    if state == 'r':
+                        state = 'g'
+                    elif state == 'g':
+                        state = 'b'
+                    else:
+                        state = None
+                        try:
+                            color = '#' + ''.join('%02X' % c if 0 <= c <= 255 else None for x in extra for c in [int(x)])
+                        except (ValueError, TypeError):
+                            pass
+                        else:
+                            sub += '<span style="%s:%s">' % ('color' if extra[0] == '38' else 'background-color', color)
+                            stack.append(extra)
+            else:
+                if '1' in stack:
+                    style = bold_style.get(c)
+                else:
+                    style = regular_style.get(c)
+                if style is not None:
+                    sub += '<span style="%s">' % style
+                    stack.append(c)  # Still needs to be added to the stack even if style is empty (so it can check '1' in stack above, for example)
+        return sub
+    stack = []
+    regular_style, bold_style, indexed_style = _ansi2html_get_styles(palette)
+    sub = ANSI2HTML_CODES_RE.sub(_ansi2html, text)
+    while stack:
+        sub += '</span>'
+        stack.pop()
+    return sub
+
+
+def main():
+    import sys
+    from optparse import OptionParser, SUPPRESS_HELP
+
+    parser = OptionParser(usage="Usage: %prog [options] [file]",
+                          description="Converts ANSI colored input to HTML.",
+                          add_help_option=False)
+    parser.add_option("-o", "--output", metavar="PATH",
+                      help="Write output to PATH (otherwise it goes to the standard output)")
+    parser.add_option("--palette", metavar="PALETTE",
+                      help="Selects a palette. Avaliable palettes are: solarized, solarized-xterm, tango, xterm, console")
+    parser.add_option("-?", action="help", help=SUPPRESS_HELP)
+    parser.add_option("-h", "--help", action="help",
+                      help="Show this message and exit")
+    parser.add_option("-v", "--version", action="store_true",
+                      help="Print version and exit")
+
+    options, args = parser.parse_args()
+
+    if options.output is not None:
+        output = open(options.output, 'wt')
+    else:
+        output = sys.stdout
+
+    try:
+        html = ''
+        if args:
+            for path in args:
+                try:
+                    html += '<pre>' + ansi2html(open(path).read(), palette=options.palette) + '</pre>'
+                except IOError:
+                    print("File not found: %r" % path, file=sys.stderr)
+        else:
+            html += '<pre>' + ansi2html(sys.stdin.read(), palette=options.palette) + '</pre>'
+        output.write(html)
+    except KeyboardInterrupt:
+        pass
+
+if __name__ == '__main__':
+    main()

--- a/rcloud.packages/rcloud.jupyter/inst/jupyter/jupyter_adapter.py
+++ b/rcloud.packages/rcloud.jupyter/inst/jupyter/jupyter_adapter.py
@@ -1,0 +1,383 @@
+"""Class for executing code using Jupyter backend"""
+
+import nbformat
+import traceback
+from nbconvert.preprocessors import ExecutePreprocessor
+from time import sleep
+import sys
+import logging
+from RCloud_ansi2html import ansi2html # MIT license from github:Kronuz/ansi2html (Oct 2014) + rename/our changes
+from xml.sax.saxutils import escape as html_escape # based on reco from moin/EscapingHtml
+import re
+from nbformat.current import NotebookNode
+from jupyter_client import KernelManager
+from jupyter_core import paths
+from jupyter_client.kernelspec import KernelSpecManager
+from jupyter_client import MultiKernelManager
+from nbformat.v4 import output_from_msg
+from traitlets import (
+    Dict, List, Unicode, Any
+)
+
+import sys
+
+import tempfile
+debugFD, debugFile = "", ""
+
+_debugging = True
+if _debugging:
+    debugFD, debugFile = tempfile.mkstemp(suffix=".log", prefix="ipy_log")
+    logging.basicConfig(filename=debugFile, level=logging.DEBUG)
+    
+class NotebookError(Exception):
+    pass
+  
+  
+class CellOutputCollector(object):
+    """
+    Component that consumes messages produced by kernel and populates cell 'outputs'.
+    """
+    error_msg = None
+    
+    def __init__(self, cell = None, cell_index = 0, _display_id_map = Dict()):
+      self.cell = cell
+      self.outs = cell.outputs = []
+      self.cell_index = cell_index
+      self._display_id_map = _display_id_map;
+    
+    def collect(self, msg):
+      msg_type = msg['msg_type']
+      logging.debug("output: %s", msg_type)
+
+      content = msg['content']
+      # set the prompt number for the input and the output
+      if 'execution_count' in content:
+          self.cell['execution_count'] = content['execution_count']
+
+      if msg_type == 'status':
+        if content['execution_state'] == 'idle':
+            return
+        else:
+            return
+      elif msg_type == 'execute_input':
+        return
+      elif msg_type == 'clear_output':
+        self.outs[:] = []
+        # clear display_id mapping for this cell
+        for display_id, cell_map in self._display_id_map.items():
+            if self.cell_index in cell_map:
+                cell_map[self.cell_index] = []
+        return
+      elif msg_type.startswith('comm'):
+        return
+            
+      display_id = None
+      if msg_type in {'execute_result', 'display_data', 'update_display_data'}:
+        display_id = msg['content'].get('transient', {}).get('display_id', None)
+        if display_id:
+            self._update_display_id(display_id, msg)
+        if msg_type == 'update_display_data':
+            # update_display_data doesn't get recorded
+            return
+
+      try:
+        out = output_from_msg(msg)
+      except ValueError:
+        logging.error("unhandled iopub msg: " + msg_type)
+        return
+      if display_id:
+        # record output index in:
+        #   _display_id_map[display_id][cell_idx]
+        cell_map = self._display_id_map.setdefault(display_id, {})
+        output_idx_list = cell_map.setdefault(self.cell_index, [])
+        output_idx_list.append(len(self.outs))
+      
+      self.outs.append(out)
+        
+    def _update_display_id(self, display_id, msg):
+        """Update outputs with a given display_id"""
+        if display_id not in self._display_id_map:
+            logging.debug("display id %r not in %s", display_id, self._display_id_map)
+            return
+
+        if msg['header']['msg_type'] == 'update_display_data':
+            msg['header']['msg_type'] = 'display_data'
+
+        try:
+            out = output_from_msg(msg)
+        except ValueError:
+            logging.error("unhandled iopub msg: " + msg['msg_type'])
+            return
+        
+        for cell_idx, output_indices in self._display_id_map[display_id].items():
+            cell = self.nb['cells'][cell_idx]
+            outputs = cell['outputs']
+            for output_idx in output_indices:
+                outputs[output_idx]['data'] = out['data']
+                outputs[output_idx]['metadata'] = out['metadata']
+
+_textFormatStr = u'<span style="font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;">{}</span>'
+
+def RClansiconv(inputtext, escape=True):
+    """ Uses Krounz/ansi2html (MIT) renamed to produce a reasonably minimal html."""
+    if _debugging: logging.debug('Received ' + inputtext)
+    txt = html_escape(inputtext) if escape else inputtext
+    txt = re.sub("\n", "<br>\n", txt)
+    txt = re.sub(" ", r"&nbsp;", txt)
+    if _debugging: logging.debug('html_escape: ' + txt)
+    try:
+        rettxt = unicode(txt, 'utf-8') # we get unicode characters from IPython sometimes
+    except:
+        rettxt = txt # if it is already unicode
+        
+    if _debugging: logging.debug('Unicode: ' + rettxt)
+    htmlFragment = ansi2html(rettxt).encode('ascii', 'xmlcharrefreplace')
+    output = _textFormatStr.format(htmlFragment.decode("utf-8"))
+    if _debugging: logging.debug('Generated html fragment: ' + output)
+    return output
+    
+class RCloudExecutePreprocessor(ExecutePreprocessor):
+    """
+    ExecutePreprocessor that manages a pool of reusable kernels.
+    """
+    
+    _kernels = Dict()
+    _clients = Dict()
+    mkm = None
+    init_script = None
+    console_in = None
+    
+    def remove_kernel(self, kernel_name):
+      if kernel_name in self._kernels:
+        kernel_id = self._kernels.pop(kernel_name)
+        if kernel_id in self._clients:
+          self._clients.pop(kernel_id)
+      
+    def init_kernel(self, startup_timeout=60, kernel_name=None, **kwargs):
+      self.get_kernel(startup_timeout=60, kernel_name=kernel_name, **kwargs)
+      
+    def start_kernel(self, kernel_name, startup_timeout=60, **kwargs):
+      if _debugging: logging.debug('Creating new kernel for name: ' + kernel_name)
+      kernel_id = self.mkm.start_kernel(kernel_name = kernel_name, **kwargs)
+      self._kernels[kernel_name] = kernel_id
+      km = self.mkm.get_kernel(self._kernels[kernel_name]);
+      kc = km.client()
+      kc.start_channels()
+      if _debugging: logging.debug('Created new kernel with name {} and id {}'.format(kernel_name, kernel_id))
+      try:
+        kc.wait_for_ready(timeout=startup_timeout)
+        kc.allow_stdin = True
+        self._clients[kernel_id] = kc
+        kc.execute(self.init_script, reply = True)
+        return kc
+      except RuntimeError:
+        kc.stop_channels()
+        km.shutdown_kernel()
+        self.remove_kernel(kernel_name)
+        raise
+    
+    def get_kernel(self, startup_timeout=60, kernel_name=None, **kwargs):
+       if self.mkm is None:
+         self.mkm = self.kernel_manager_class()
+       
+       if kernel_name is None:
+         kernel_name = self.kernel_name
+
+       if kernel_name in self._kernels and not self.mkm.is_alive(self._kernels[kernel_name]):
+         self.remove_kernel(kernel_name)
+      
+       if not kernel_name in self._kernels:
+         return self.start_kernel(kernel_name, startup_timeout = startup_timeout, **kwargs)
+      
+       kernel_id = self._kernels[kernel_name]
+       if _debugging: logging.debug('Reusing existing kernel with id {} for name {} '.format(kernel_id, kernel_name))
+       kc = self._clients[kernel_id]
+       return kc
+
+    def run_cell(self, cell, cell_index=0):
+        cell_output_collector = CellOutputCollector(cell, cell_index, self._display_id_map)
+        self.kc.execute_interactive(cell.source, allow_stdin = True, stdin_hook = self.stdin_hook, output_hook = cell_output_collector.collect)
+        return cell_output_collector.error_msg, cell_output_collector.outs
+
+    def preprocess(self, nb, resources):
+        """
+        Preprocess notebook executing each code cell.
+
+        The input argument `nb` is modified in-place.
+
+        Parameters
+        ----------
+        nb : NotebookNode
+            Notebook being executed.
+        resources : dictionary
+            Additional resources used in the conversion process. For example,
+            passing ``{'metadata': {'path': run_path}}`` sets the
+            execution path to ``run_path``.
+
+        Returns
+        -------
+        nb : NotebookNode
+            The executed notebook.
+        resources : dictionary
+            Additional resources used in the conversion process.
+        """
+        path = resources.get('metadata', {}).get('path', '')
+        if path == '':
+            path = None
+        
+        # clear display_id map
+        self._display_id_map = {}
+
+        kernel_name = nb.metadata.get('kernelspec', {}).get('name', self.kernel_name)
+        
+        self.log.info("Executing notebook with kernel: %s" % kernel_name)
+        self.kc = self.get_kernel(
+          startup_timeout=self.startup_timeout,
+          kernel_name=kernel_name,
+          extra_arguments=self.extra_arguments,
+          cwd=path)
+        
+        self.nb = nb
+
+        nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)
+
+        delattr(self, 'nb')
+        delattr(self, 'kc')
+
+        return nb, resources
+
+    def shutdown_kernel(self):
+      if _debugging: logging.info('Shutting down kernels.')
+      if self.mkm is not None:
+          self.mkm.shutdown_all(now = self.shutdown_kernel == 'immediate')
+
+    def stdin_hook(self, msg):
+        """Handle an input request"""
+        content = msg['content']
+        prompt = self.console_in
+
+        try:
+            raw_data = prompt(content["prompt"])
+        except EOFError:
+            # turn EOFError into EOF character
+            raw_data = '\x04'
+        except KeyboardInterrupt:
+         #   sys.stdout.write('\n')
+            return
+
+        # only send stdin reply if there *was not* another request
+        # or execution finished while we were reading.
+        if not (self.kc.stdin_channel.msg_ready() or self.kc.shell_channel.msg_ready()):
+            self.kc.input(raw_data)
+    
+    def complete(self, text, kernel_name = None, pos = None):
+      kc = self.get_kernel(self.startup_timeout, kernel_name, extra_arguments=self.extra_arguments)
+      try:
+        res = kc.complete(text, int(pos) if pos is not None else None, reply=True, timeout = 5)
+        if res is None or res['content']['status'] not in ('ok'):
+          return None
+        if _debugging: logging.info('Completions: ' + ','.join(res['content']['matches']))
+        return res['content']
+      except:
+        if _debugging: logging.info('Could not fetch completion suggestions: ' + traceback.format_exc())
+        return None
+
+class JupyterAdapter(object):
+    # The kernel communicates with mime-types while the notebook
+    # uses short labels for different cell types. We'll use this to
+    # map from kernel types to notebook format types.
+
+    MIME_MAP = {
+        'image/jpeg': 'jpeg',
+        'image/png': 'png',
+        'text/plain': 'text',
+        'text/html': 'html',
+        'text/latex': 'latex',
+        'application/javascript': 'html',
+        'application/json': 'json'
+    }
+    
+    
+    def __init__(self, init_script = '', console_in = None, 
+                kernel_startup_timeout = 600, cell_exec_timeout=600, kernel_name='python',
+                **kw):
+        """Initializes the Jupyter Adapter"""
+
+        self.executePreprocessor = RCloudExecutePreprocessor(startup_timeout = kernel_startup_timeout, timeout = cell_exec_timeout, 
+                                                            kernel_name = kernel_name,  kernel_manager_class=MultiKernelManager, 
+                                                            console_in = console_in, init_script = init_script)
+
+    def get_kernel_specs(self):
+        return KernelSpecManager().get_all_specs()
+        
+    def get_jupyter_path(self, path):
+        return paths.jupyter_path(path)
+
+    def __del__(self):
+        self.executePreprocessor.shutdown_kernel()
+
+    def shutdown(self):
+        self.executePreprocessor.shutdown_kernel()
+
+    def complete(self, text, kernel_name = None, pos = None):
+        return self.executePreprocessor.complete(kernel_name, text, pos)
+
+    def run_cmd(self, cmd, kernel_name = None):
+        """
+        Runs python command string.
+        """
+        notebook = nbformat.v4.new_notebook()
+        my_cell = nbformat.v4.new_code_cell(source=cmd)
+        notebook.cells = [my_cell]
+        if kernel_name:
+          notebook.metadata['kernelspec'] = {'name' : kernel_name}
+          
+        try:
+          self.executePreprocessor.preprocess(notebook, {'metadata': {'path': '.' }})
+          if _debugging: logging.info('Result notebook: ' + nbformat.v4.writes_json(notebook))
+          if len(notebook.cells) < 1 or len(notebook.cells[0].outputs) < 1:
+            return None
+          return self.postprocess_output(notebook.cells[0].outputs)
+        except:
+          exc_type, exc_obj, exc_tb = sys.exc_info()
+          
+          msg = None
+          if _debugging: 
+            msg = '\n'.join(traceback.format_exception_only(exc_type, exc_obj) + traceback.format_tb(exc_tb))
+          else:
+            msg = '\n'.join(traceback.format_exception_only(exc_type, exc_obj))
+          
+          out = NotebookNode(output_type = 'error', html = RClansiconv(msg + '\n'))
+          return [out]
+          
+    def postprocess_output(self, outputs):
+        """
+        Postprocesses output and maps mime types to ones accepted by R.
+        """
+        res = []
+        for output in outputs:
+          msg_type = output.output_type
+          content = output
+          out = NotebookNode(output_type = msg_type)
+          if msg_type in ('display_data', 'execute_result'):
+            for mime, data in content['data'].items():
+                try:
+                    attr = self.MIME_MAP[mime]
+                    if attr == 'text':
+                      tmpval =  RClansiconv(data) 
+                    else:
+                      tmpval = data
+                    setattr(out, attr, tmpval)
+                except KeyError:
+                    raise NotImplementedError('unhandled mime type: %s' % mime)
+          elif msg_type == 'stream':
+              setattr(out, 'text', RClansiconv(content['text']))
+          elif msg_type == 'error':
+              setattr(out, 'html', RClansiconv('\n'.join(content['traceback']) + '\n'))
+          else:
+              if _debugging: logging.info('Unsupported: ' + msg_type)
+              raise NotImplementedError('unhandled result: %s' % msg_type)
+          if _debugging: logging.info('Sending: msg_type: [{}]; HTML: [{}]; TEXT: [{}]'.format(msg_type, out.get('html', ''), out.get('text', '') ))
+          res.append(out)
+        return res # upstream process will handle it [e.g. send as an oob message]
+


### PR DESCRIPTION
Main differences to what was included in PR https://github.com/att/rcloud/pull/2566 are:

* renamed rcloud.conf properties to rcloud.jupyter.*
* renamed some of the functions so they mention 'jupyter' instead of 'python' (where applicable)
* Improved README.md and included steps covering registration of rcloud.jupyter as rcloud.language