### PR TITLE
Fix invalid method name.

### DIFF
--- a/rcloud.packages/rcloud.jupyter/R/main.R
+++ b/rcloud.packages/rcloud.jupyter/R/main.R
@@ -169,12 +169,18 @@ JUPYTER_CONNECTION_DIR_PATH <- 'rcloud.jupyter.connection_dir.path'
   rcloud.session$jupyter.adapter <- runner
   
   f <- .GlobalEnv$.Rserve.done
+  session <- rcloud.session
   
-  .GlobalEnv$.Rserve.done <- function(...) { 
-    .stop.jupyter.adapter(rcloud.session); 
-    if (is.function(f)) 
-      f(...) 
+  .GlobalEnv$.Rserve.done <- function(...) {
+    tryCatch({
+      .stop.jupyter.adapter(session)
+    }, error=function(e) {
+      warning(paste("Process id", Sys.getpid(), "session id", session$sessionID, " error during jupyter adapter shutdown: " , e, "\n"))
+    })
+    if (is.function(f)) {
+      f(...)
     }
+  }
 }
 
 #'

--- a/rcloud.packages/rcloud.jupyter/inst/jupyter/jupyter_adapter.py
+++ b/rcloud.packages/rcloud.jupyter/inst/jupyter/jupyter_adapter.py
@@ -10,7 +10,7 @@ import logging
 from RCloud_ansi2html import ansi2html # MIT license from github:Kronuz/ansi2html (Oct 2014) + rename/our changes
 from xml.sax.saxutils import escape as html_escape # based on reco from moin/EscapingHtml
 import re
-from nbformat.current import NotebookNode
+from nbformat.notebooknode import NotebookNode
 from jupyter_client import KernelManager
 from jupyter_core import paths
 from jupyter_client.kernelspec import KernelSpecManager

--- a/rcloud.packages/rcloud.jupyter/inst/jupyter/jupyter_adapter.py
+++ b/rcloud.packages/rcloud.jupyter/inst/jupyter/jupyter_adapter.py
@@ -252,7 +252,7 @@ class RCloudExecutePreprocessor(ExecutePreprocessor):
 
         return nb, resources
 
-    def shutdown_kernel(self):
+    def shutdown(self):
       if _debugging: logging.info('Shutting down kernels.')
       if self.mkm is not None:
           self.mkm.shutdown_all(now = self.shutdown_kernel == 'immediate')
@@ -323,10 +323,10 @@ class JupyterAdapter(object):
         return paths.jupyter_path(path)
 
     def __del__(self):
-        self.executePreprocessor.shutdown_kernel()
+        self.executePreprocessor.shutdown()
 
     def shutdown(self):
-        self.executePreprocessor.shutdown_kernel()
+        self.executePreprocessor.shutdown()
 
     def complete(self, text, kernel_name = None, pos = None):
         return self.executePreprocessor.complete(kernel_name, text, pos)


### PR DESCRIPTION
In Jupyter adapter script one of the method was named the same way as objects attribute, because of this kernels were never stopped.

Relates to #2570 