### PR TITLE
Improve handling of errors during notebook creation.

### DIFF
--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -376,9 +376,17 @@ rcloud.create.notebook <- function(content, is.current = TRUE) {
         }
     }
     res <- rcloud.augment.notebook(res)
-    ulog("INFO: rcloud.create.notebook (", res$content$id, ")")
+    if(res$ok) {
+      ulog("INFO: rcloud.create.notebook (", res$content$id, ")")
+    } else {
+      if('code' %in% names(res)) {
+        ulog("ERROR: rcloud.create.notebook failed (", res$code, ")")
+      } else {
+        ulog("ERROR: rcloud.create.notebook failed")
+      }
+    }
     res
-  }, error = function(e) { list(ok = FALSE) })
+  }, error = function(e) { list(ok = FALSE, content = list (message = as.character(e))) })
 }
 
 rcloud.rename.notebook <- function(id, new.name) {


### PR DESCRIPTION
Small improvement to handling errors that may happen during creation of a notebook, before when creation of a notebook failed, the error was masked by error thrown at line 379:

```
ulog("INFO: rcloud.create.notebook (", res$content$id, ")")
```

I also added a page covering configuration of gist service so it supports forking/import of notebooks larger than 10MB: https://github.com/att/rcloud-gist-services/wiki/LargeNotebooksSupport