### PR TITLE
Turn off detailed diff generation for large files.

### DIFF
--- a/htdocs/js/ui/notebook_merger/merger_controller.js
+++ b/htdocs/js/ui/notebook_merger/merger_controller.js
@@ -7,7 +7,7 @@ RCloudNotebookMerger.controller = (function(model, view) {
     }
 
     show_dialog() {
-      this._model.get_notebook_merge_property();
+      this._view.open();
     }
     
     submit_dialog() {

--- a/htdocs/js/ui/notebook_merger/merger_view.js
+++ b/htdocs/js/ui/notebook_merger/merger_view.js
@@ -638,6 +638,10 @@ RCloudNotebookMerger.view = (function(model) {
         this._dialog.setMergerDialogStage(stage.toLowerCase());
     }
     
+    open() {
+      this._model.get_notebook_merge_property();
+    }
+    
     is_open() {
       return this._dialog.is(':visible');
     }


### PR DESCRIPTION
In case of larger files (greater than 0.25MB) generating a diff resulted in a long execution of JS and/or crashing a web browser.

If a file is greater than 0.25MB the diff representing a replacement of whole file contents is generated to avoid the above issues.

This change also improves the performance of generating diffs for new and deleted cells/assets as the diff library isn't unnecessarily executed for such files.

Some minor linting of API.

@gordonwoodhull this is a set of changes that I hadn't finished off before https://github.com/att/rcloud/pull/2592 got merged