### PR TITLE
Bugfix/Issue 2598

### DIFF
--- a/htdocs/js/ui/notebook_title.js
+++ b/htdocs/js/ui/notebook_title.js
@@ -20,7 +20,7 @@ RCloud.UI.notebook_title = (function() {
                 if(node.gistname === shell.gistname())
                     rename_current_notebook(name);
                 else {
-                    rcloud.update_notebook(node.gistname, {description: name}, false)
+                    rcloud.update_notebook(node.gistname, update_notebook_from_gist, {description: name}, false)
                         .then(function(notebook) {
                             editor.update_notebook_from_gist(notebook);
                         });


### PR DESCRIPTION
When renaming a pre-existing folder in the tree, an error log would display as there was a scoping issue with the update_notebook_from_gist function.