### PR TITLE
Remove unwanted Monaco decorations

### DIFF
--- a/htdocs/js/ui/notebook_merger/merger_view.js
+++ b/htdocs/js/ui/notebook_merger/merger_view.js
@@ -308,12 +308,14 @@ RCloudNotebookMerger.view = (function(model) {
         let content_area = this._compare_stage.find(`div[data-filetype="${args.fileType}"][data-filename="${filename}"]`);
         let panel_loader = content_area.closest('.panel').find('.diffLoader');
 
+        // Resizing of the Monaco editor panel.
         let sizeDiffPanel = (panelContent, lineCount, changesCount, editorConfiguration) => {
-            /*
-               Set size of panel body explicitly so Monaco editor displays correctly
-            */
-            let computedWidth = panelContent.innerWidth();
-            panelContent.css('width', computedWidth + 'px');
+
+            // The following sits the editor panel over the top of the margin (numbers).
+            panelContent.css('left', 0 + 'px');
+            panelContent.css('right', 0 + 'px');
+
+            // Calculates the height needed for the Monaco editor depending on the changes present.
             let height = (lineCount + changesCount) * editorConfiguration.lineHeight;
             panelContent.css('height', height + 'px');
         };
@@ -350,6 +352,11 @@ RCloudNotebookMerger.view = (function(model) {
                 // Layout
                 sizeDiffPanel(editor_container,  editor_model.getLineCount(), diff.modifiedLineInfo.length, this._editors[filename].editor.getConfiguration());
 
+                // Hide the default Monaco decorations.
+                $('.monaco-scrollable-element').each(function() {
+                  this.style.left = '0px';
+                  this.style.width = '110%';
+                })
 
                 this._editors[filename].editor.layout();
 
@@ -398,6 +405,12 @@ RCloudNotebookMerger.view = (function(model) {
 
                   // Layout
                   sizeDiffPanel(editor_container,  editor_model.getLineCount(), 0, this._editors[filename].editor.getConfiguration());
+
+                  // Hide the default Monaco decorations.
+                $('.monaco-scrollable-element').each(function() {
+                  this.style.left = '0px';
+                  this.style.width = '110%';
+                })
 
                   this._editors[filename].editor.layout();
 


### PR DESCRIPTION
This hides the various Monaco decorations by moving the main editor panel across the unwanted parts. Much cleaner!

Fixes #2616 and #2613 