### PR TITLE
Fix to the folder renaming issue.

### DIFF
--- a/htdocs/editor_tab.js
+++ b/htdocs/editor_tab.js
@@ -802,6 +802,9 @@ var editor = function () {
         },
         traverse_tree: function() {
             tree_controller_.traverse();
+        },
+        update_notebook_from_gist: function(gistname) {
+            return tree_controller_.update_notebook_from_gist(gistname);
         }
     };
     return result;


### PR DESCRIPTION
Folders can now be renamed without throwing any errors, even if they have numerous notebooks inside of them. 

Ashamed to say this one took a lot longer than it should have done and the fix was easier than I anticipated! 

Fixes #2598 