### PR TITLE
Display Notebook ID in Info Popup and allow user to Copy to Clipboard.

### DIFF
--- a/htdocs/sass/components/rcloud-base.scss
+++ b/htdocs/sass/components/rcloud-base.scss
@@ -1180,3 +1180,49 @@ body .modal-dialog.full {
         }
     }
 }
+
+/* Styles specific to the Copy-To-Clipboard functionality 
+    for the Notebook Info panel. */
+
+    .clipboard-tooltip {
+        position: relative;
+        display: inline-block;
+    }
+    
+    .clipboard-tooltip .clipboard-tooltip-text {
+        font-family: Helvetica, Arial, sans-serif;
+        visibility: hidden;
+        width: 140px;
+        background-color: #000;
+        color: #fff;
+        text-align: center;
+        border-radius: 6px;
+        padding: 5px;
+        position: absolute;
+        z-index: 1;
+        bottom: 150%;
+        left: 50%;
+        margin-left: -75px;
+        opacity: 0;
+        transition: opacity 0.3s;
+    }
+    
+    .clipboard-tooltip .clipboard-tooltip-text:after {
+        content: "";
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-width: 5px;
+        border-style: solid;
+        border-color: #000 transparent transparent transparent;
+    }
+    
+    .icon-file-text:hover {
+        cursor: pointer;
+    }
+    
+    .clipboard-tooltip:hover .clipboard-tooltip-text {
+        visibility: visible;
+        opacity: 1;
+    }

--- a/rcloud.packages/rcloud.notebook.info/inst/javascript/rcloud.notebook.info.js
+++ b/rcloud.packages/rcloud.notebook.info/inst/javascript/rcloud.notebook.info.js
@@ -34,6 +34,12 @@
                                         list = [list];
 
                                     var close_button = '<span class="pop-close" style="cursor: pointer; float:right;">x</span>';
+
+                                    //Display the current Notebook ID
+                                    var getID = node.gistname;
+                                    var displayID = '<div class="info-category"><b>ID: </b><i class="icon-file-text clipboard-tooltip">\
+                                                        <span class="clipboard-tooltip-text">Copy ID to Clipboard</span></i></div>' + getID;
+                                    
                                     var group_message = '<div class="info-category"><b>Group:</b></div>';
 
                                     if(cryptogroup && cryptogroup.id === 'private' && cryptogroup.name === null)
@@ -47,7 +53,7 @@
                                     list.forEach(function (v) {
                                         starrer_list = starrer_list + '<div class="info-item">' + v + '</div>';
                                     });
-                                    return group_message + info_content + starrer_list;
+                                    return displayID + group_message + info_content + starrer_list;
                                 };
 
                                 function wrapGroupType(name) {
@@ -89,6 +95,16 @@
                                     thisPopover = $(thisPopover);
                                     thisPopover.addClass('popover-offset notebook-info');
                                     popupOpen = true;
+
+                                    // Copy node.gistname to clipboard ready for merge dialogue.
+                                    $('.icon-file-text', thisPopover).click(function () {
+                                        var copy = node.gistname;
+                                        var copyClip = $('<input>').val(copy).appendTo('body').select();
+                                        document.execCommand('copy');
+
+                                        var tooltip = document.querySelector('.clipboard-tooltip-text');
+                                        tooltip.innerHTML = "Copied Notebook ID";
+                                    })
                                 }
                                 else {
                                     $(document).trigger('destroy_all_popovers');

--- a/rcloud.packages/rcloud.notebook.info/inst/javascript/rcloud.notebook.info.js
+++ b/rcloud.packages/rcloud.notebook.info/inst/javascript/rcloud.notebook.info.js
@@ -37,7 +37,7 @@
 
                                     //Display the current Notebook ID
                                     var getID = node.gistname;
-                                    var displayID = '<div class="info-category"><b>ID: </b><i class="icon-file-text clipboard-tooltip">\
+                                    var displayID = '<div class="info-category"><b>ID: </b><i class="icon-copy clipboard-tooltip">\
                                                         <span class="clipboard-tooltip-text">Copy ID to Clipboard</span></i></div>' + getID;
                                     
                                     var group_message = '<div class="info-category"><b>Group:</b></div>';
@@ -97,7 +97,7 @@
                                     popupOpen = true;
 
                                     // Copy node.gistname to clipboard ready for merge dialogue.
-                                    $('.icon-file-text', thisPopover).click(function () {
+                                    $('.icon-copy', thisPopover).click(function () {
                                         var copy = node.gistname;
                                         var copyClip = $('<input>').val(copy).appendTo('body').select();
                                         document.execCommand('copy');


### PR DESCRIPTION
Notebook ID now displays in the pop up information and can be copied to the users clipboard ready to use in the merge dialogue.

Fixes #2594 
