### PR TITLE
Merge Into Current Notebook Button & Folder Delete Fix

### DIFF
--- a/htdocs/js/ui/notebook_commands.js
+++ b/htdocs/js/ui/notebook_commands.js
@@ -1,5 +1,6 @@
 RCloud.UI.notebook_commands = (function() {
     var icon_style_ = {'line-height': '90%'};
+    var merge_icon_style_ = {'line-height': '90%', 'padding-right': '3px'};
     var star_style_ = _.extend({'font-size': '80%'}, icon_style_);
     var star_states_ = {true: {'class': 'icon-star', title: 'unstar'},
                         false: {'class': 'icon-star-empty', title: 'star'}};
@@ -205,6 +206,9 @@ RCloud.UI.notebook_commands = (function() {
         },
         icon_style: function() {
             return icon_style_;
+        },
+        merge_icon_style: function() {
+            return merge_icon_style_;
         },
         decorate: function($li, node, right) {
             var appeared;

--- a/htdocs/js/ui/notebook_commands.js
+++ b/htdocs/js/ui/notebook_commands.js
@@ -171,8 +171,10 @@ RCloud.UI.notebook_commands = (function() {
                                 editor.for_each_notebook(node, null, function(node) {
                                     promises.push(editor.remove_notebook(node.user, node.gistname));
                                 });
-                            };
-                            return false;
+                            } else {
+                                notebook_names = [];
+                                return false;
+                            }
                         });
                         return remove_folder;
                     }

--- a/htdocs/js/ui/notebook_commands.js
+++ b/htdocs/js/ui/notebook_commands.js
@@ -116,7 +116,7 @@ RCloud.UI.notebook_commands = (function() {
                 },
                 remove: {
                     section: 'appear',
-                    sort: 4000,
+                    sort: 5000,
                     condition1: function(node) {
                         return node.user === editor.username();
                     },

--- a/htdocs/js/ui/notebook_merger/notebook_merge.js
+++ b/htdocs/js/ui/notebook_merger/notebook_merge.js
@@ -32,18 +32,24 @@ RCloud.UI.addons.notebook_merge = (function() {
       init: () => {
           const merger_dialog = new notebook_merger_dialog_widget();
 
+          /* Create a merge button in the notebook tree and 
+              start a new Merge dialogue with the desired Notebook */
           RCloud.UI.notebook_commands.add({
             merge: {
               section: 'appear',
               sort: 4000,
-              condition1: function(node) {
-                return node.user === editor.username()
+              condition1: function (node) {
+                return node.user === editor.username();
               },
-              create: function(node) {
+              create: function (node) {
                 var merge = ui_utils.fa_button('icon-code-fork icon-rotate-90', 'merge', 'merge', RCloud.UI.notebook_commands.icon_style(), true);
-                merge.click(function(e) {
-                  merger_dialog.show()
+                merge.click(function (e) {
+                  merger_dialog.show();
+                  var mergeSource = document.getElementById('merge-changes-by');
+                  var mergeID = document.getElementById('merge-notebook-id');
+                  mergeID.value = node.gistname;
                 })
+                return merge;
               }
             }
           }),

--- a/htdocs/js/ui/notebook_merger/notebook_merge.js
+++ b/htdocs/js/ui/notebook_merger/notebook_merge.js
@@ -44,10 +44,14 @@ RCloud.UI.addons.notebook_merge = (function() {
               create: function (node) {
                 var merge = ui_utils.fa_button('icon-code-fork icon-rotate-90', 'merge', 'merge', RCloud.UI.notebook_commands.merge_icon_style(), true);
                 merge.click(function (e) {
+                  // Open merge dialogue
                   merger_dialog.show();
-                  var mergeSource = document.getElementById('merge-changes-by');
-                  var mergeID = document.getElementById('merge-notebook-id');
-                  mergeID.value = node.gistname;
+                  // Submit to next dialogue or fail if ID invalid.
+                  setTimeout(function() {
+                    $('#merge-notebook-id').val(node.gistname);
+                    $('.show-changes').click();
+                  }, 100);
+                  return;
                 })
                 return merge;
               }

--- a/htdocs/js/ui/notebook_merger/notebook_merge.js
+++ b/htdocs/js/ui/notebook_merger/notebook_merge.js
@@ -42,7 +42,7 @@ RCloud.UI.addons.notebook_merge = (function() {
                 return node.user === editor.username();
               },
               create: function (node) {
-                var merge = ui_utils.fa_button('icon-code-fork icon-rotate-90', 'merge', 'merge', RCloud.UI.notebook_commands.icon_style(), true);
+                var merge = ui_utils.fa_button('icon-code-fork icon-rotate-90', 'merge', 'merge', RCloud.UI.notebook_commands.merge_icon_style(), true);
                 merge.click(function (e) {
                   merger_dialog.show();
                   var mergeSource = document.getElementById('merge-changes-by');

--- a/htdocs/js/ui/notebook_merger/notebook_merge.js
+++ b/htdocs/js/ui/notebook_merger/notebook_merge.js
@@ -31,6 +31,22 @@ RCloud.UI.addons.notebook_merge = (function() {
   return {
       init: () => {
           const merger_dialog = new notebook_merger_dialog_widget();
+
+          RCloud.UI.notebook_commands.add({
+            merge: {
+              section: 'appear',
+              sort: 4000,
+              condition1: function(node) {
+                return node.user === editor.username()
+              },
+              create: function(node) {
+                var merge = ui_utils.fa_button('icon-code-fork icon-rotate-90', 'merge', 'merge', RCloud.UI.notebook_commands.icon_style(), true);
+                merge.click(function(e) {
+                  merger_dialog.show()
+                })
+              }
+            }
+          }),
           RCloud.UI.shortcut_manager.add([{
             category: 'Advanced',
             id: 'merger-dialog-submit',


### PR DESCRIPTION
Fixes #2597 & Fixes #2612 

The merge button is displayed in the tree, and when clicked on will open a new merge dialogue. The ID of the notebook that the user clicked on will automatically be present in the ID input box allowing the user to continue.

I wasn't sure whether the intention of this feature was to take the user straight through to the "Stage Changes" dialogue, but actually I think directing to the initial merge screen is perhaps a more graceful solution as it gives the user a "confirmation" screen, rather than staging the changes, incase the Merge button was clicked on accidentally.


I added the fix to the folder renaming issue just because it was a quick fix in the same file I had been working in.