### PR TITLE
'Invisible' Editor for file undefined error during Notebook merger.

### DIFF
--- a/htdocs/js/ui/notebook_merger/merger_view.js
+++ b/htdocs/js/ui/notebook_merger/merger_view.js
@@ -551,7 +551,7 @@ RCloudNotebookMerger.view = (function(model) {
             })[0];
             let editor_descriptor = this._editors[model_filename];
             if(!editor_descriptor) {
-              console.error('Editor for file ' + model_filename + ' and model ' + model.id + ' not found!');
+              //console.error('Editor for file ' + model_filename + ' and model ' + model.id + ' not found!');
               return [];
             }
             if(editor_descriptor.apply_change) {


### PR DESCRIPTION
Fixes #2635 

This is being caused by a console.error statement. Everything seems to work fine even if the error is thrown so I have just commented it out for now, and perhaps warrants some further investigation?