### PR TITLE
sanitize errors in notebook.R to prevent reflected XSS

### DIFF
--- a/htdocs/notebook.R
+++ b/htdocs/notebook.R
@@ -104,6 +104,6 @@ run <- function(url, query, body, headers)
       list(payload, type)
     }
   }, error=function(e) {
-    list(paste(et,"<pre>", paste(as.character(e), collapse='\n'), "</pre>"), "text/html", character(), 500L)
+    list(paste(et,"<pre>", sanitize.error(paste(as.character(e), collapse='\n')), "</pre>"), "text/html", character(), 500L)
   })
 }

--- a/rcloud.support/R/http.R
+++ b/rcloud.support/R/http.R
@@ -1,3 +1,10 @@
+sanitize.error <- function(x)
+  gsub('<', '&lt;',
+       gsub('>', '&gt;',
+            gsub("'", '&apos;',
+                 gsub('"', '&quot;',
+                      gsub('&', '&amp;', x)))))
+
 ## this serves Rserve's built-in HTTP server
 .http.request <- function(url, query, body, headers, ...) {
     if (nzConf("http.user")) {


### PR DESCRIPTION
Hi @s-u, requesting your review on this fix we discussed last week.

I cleaned it up slightly by sanitizing the output rather than the inputs. Although notebook.R can `return()` other errors, I don't think they are vulnerable to XSS. I haven't reviewed the other scripts, but I would propose fixing them the same way.

I bet there is a better way to do multiple replacements but I didn't find it.