### PR TITLE
rcloud.conf option github.use.query.token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,11 @@
  * Sharable Link tooltip shows the view type (#2723)
  * New Cell buttons are faster (#2731)
 
+### Features
+ * Compatible with HTTP Basic Authentication for `github.com`. The option is `github.use.basic.auth`
+   and defaults `false` for compatibility with
+   [rcloud-gist-services](https://github.com/att/rcloud-gist-services)
+
 ### Bugfixes
  * `rcloud.download.file()` failed to insert newlines between
     character vector elements (#2721)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,10 +13,12 @@
  * Sharable Link tooltip shows the view type (#2723)
  * New Cell buttons are faster (#2731)
 
-### Features
- * Compatible with HTTP Basic Authentication for `github.com`. The option is `github.use.basic.auth`
-   and defaults `false` for compatibility with
-   [rcloud-gist-services](https://github.com/att/rcloud-gist-services)
+### Improvements
+ * Ability to send token in the headers instead in query string, via rgithub 0.9.12. GitHub is
+   sending deprecation emails about this. `github.use.query.token` defaults `false` for
+   compatibility with GitHub, and can be set `true` for compatibility with
+   [rcloud-gist-services](https://github.com/att/rcloud-gist-services). Setting
+   `rational.githubgist` true will also set this flag.
 
 ### Bugfixes
  * `rcloud.download.file()` failed to insert newlines between

--- a/conf/rcloud.conf.samp
+++ b/conf/rcloud.conf.samp
@@ -8,6 +8,8 @@ github.client.secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 github.base.url: https://github.com/
 github.api.url: https://api.github.com/
 github.gist.url: https://gist.github.com/
+#--: omit for rcloud-gist-services
+github.use.basic.auth: true
 #gist.backend: gitgist
 #gist.git.root: ${ROOT}/data/gists
 rcs.engine: redis

--- a/conf/rcloud.conf.samp
+++ b/conf/rcloud.conf.samp
@@ -9,7 +9,7 @@ github.base.url: https://github.com/
 github.api.url: https://api.github.com/
 github.gist.url: https://gist.github.com/
 #--: omit for rcloud-gist-services
-github.use.basic.auth: true
+github.use.query.token: false
 #gist.backend: gitgist
 #gist.git.root: ${ROOT}/data/gists
 rcs.engine: redis
@@ -17,5 +17,5 @@ rcs.engine: redis
 rcloud.alluser.addons: rcloud.viewer, rcloud.enviewer, rcloud.notebook.info, rcloud.htmlwidgets, rcloud.rmd, rcloud.flexdashboard, rcloud.jupyter.notebooks, rcloud.shiny
 rcloud.languages: rcloud.r, rcloud.jupyter, rcloud.rmarkdown, rcloud.sh
 compute.separation.modes: IDE
-#--: if using rcloud-gist-service
+#--: if using rcloud-gist-services
 #rational.githubgist: true

--- a/conf/rcloud.conf.samp
+++ b/conf/rcloud.conf.samp
@@ -8,8 +8,6 @@ github.client.secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 github.base.url: https://github.com/
 github.api.url: https://api.github.com/
 github.gist.url: https://gist.github.com/
-#--: omit for rcloud-gist-services
-github.use.query.token: false
 #gist.backend: gitgist
 #gist.git.root: ${ROOT}/data/gists
 rcs.engine: redis

--- a/packages/githubgist/DESCRIPTION
+++ b/packages/githubgist/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: githubgist
 Title: Gist interface to GitHub
-Version: 1.0-6
+Version: 1.0-7
 Author: Simon Urbanek <urbanek@research.att.com>
 Maintainer: Simon Urbanek <urbanek@research.att.com>
 Description: Gist interface to GitHub
-Imports: gist, github (>= 0.9.11), httr
+Imports: gist, github (>= 0.9.12), httr
 License: MIT

--- a/packages/githubgist/DESCRIPTION
+++ b/packages/githubgist/DESCRIPTION
@@ -4,5 +4,5 @@ Version: 1.0-6
 Author: Simon Urbanek <urbanek@research.att.com>
 Maintainer: Simon Urbanek <urbanek@research.att.com>
 Description: Gist interface to GitHub
-Imports: gist, github (>= 0.9.9), httr
+Imports: gist, github (>= 0.9.11), httr
 License: MIT

--- a/packages/githubgist/R/do.R
+++ b/packages/githubgist/R/do.R
@@ -1,8 +1,9 @@
-config.options <- function() list(github.api.url=TRUE, github.base.url=FALSE, github.client.id=FALSE, github.client.secret=FALSE, github.auth.forward=FALSE)
+config.options <- function() list(github.api.url=TRUE, github.base.url=FALSE, github.client.id=FALSE, github.client.secret=FALSE, github.use.basic.auth=FALSE, github.auth.forward=FALSE)
 
-create.gist.context <- function(username, token, github.api.url, github.client.id, github.client.secret, github.base.url, ...) {
+create.gist.context <- function(username, token, github.api.url, github.client.id, github.client.secret, github.base.url, github.use.basic.auth, ...) {
   if ((is.character(token) && !isTRUE(nzchar(token))) || is.null(github.client.secret) || is.null(github.client.id)) token <- NULL ## github requires token to be NULL if not used
-  ctx <- github::create.github.context(api_url=github.api.url, client_id=github.client.id, client_secret=github.client.secret, access_token=token)
+  use_basic_auth <- if(is.null(github.use.basic.auth)) FALSE else as.logical(github.use.basic.auth)
+  ctx <- github::create.github.context(api_url=github.api.url, client_id=github.client.id, client_secret=github.client.secret, access_token=token, use_basic_auth=use_basic_auth)
   ctx$github.base.url=github.base.url
   ctx$read.only <- is.null(token)
   ctx$gist.params <- list(...)

--- a/packages/githubgist/R/do.R
+++ b/packages/githubgist/R/do.R
@@ -1,9 +1,14 @@
-config.options <- function() list(github.api.url=TRUE, github.base.url=FALSE, github.client.id=FALSE, github.client.secret=FALSE, github.use.basic.auth=FALSE, github.auth.forward=FALSE)
+config.options <- function() list(github.api.url=TRUE, github.base.url=FALSE, github.client.id=FALSE, github.client.secret=FALSE, github.use.query.token=FALSE, github.auth.forward=FALSE, rational.githubgist=FALSE)
 
-create.gist.context <- function(username, token, github.api.url, github.client.id, github.client.secret, github.base.url, github.use.basic.auth, ...) {
+use.query.token <- function(github.use.query.token, rational.githubgist) {
+  if(!is.null(github.use.query.token)) return(as.logical(github.use.query.token))
+  if(!is.null(rational.githubgist)) return(as.logical(rational.githubgist))
+  return(TRUE)
+}
+
+create.gist.context <- function(username, token, github.api.url, github.client.id, github.client.secret, github.base.url, github.use.query.token, rational.githubgist, ...) {
   if ((is.character(token) && !isTRUE(nzchar(token))) || is.null(github.client.secret) || is.null(github.client.id)) token <- NULL ## github requires token to be NULL if not used
-  use_basic_auth <- if(is.null(github.use.basic.auth)) FALSE else as.logical(github.use.basic.auth)
-  ctx <- github::create.github.context(api_url=github.api.url, client_id=github.client.id, client_secret=github.client.secret, access_token=token, use_basic_auth=use_basic_auth)
+  ctx <- github::create.github.context(api_url=github.api.url, client_id=github.client.id, client_secret=github.client.secret, access_token=token, use_query_token=use.query.token(github.use.query.token, rational.githubgist))
   ctx$github.base.url=github.base.url
   ctx$read.only <- is.null(token)
   ctx$gist.params <- list(...)

--- a/packages/githubgist/R/do.R
+++ b/packages/githubgist/R/do.R
@@ -3,7 +3,7 @@ config.options <- function() list(github.api.url=TRUE, github.base.url=FALSE, gi
 use.query.token <- function(github.use.query.token, rational.githubgist) {
   if(!is.null(github.use.query.token)) return(as.logical(github.use.query.token))
   if(!is.null(rational.githubgist)) return(as.logical(rational.githubgist))
-  return(TRUE)
+  return(FALSE)
 }
 
 create.gist.context <- function(username, token, github.api.url, github.client.id, github.client.secret, github.base.url, github.use.query.token, rational.githubgist, ...) {

--- a/rcloud.support/R/rcloud.support.R
+++ b/rcloud.support/R/rcloud.support.R
@@ -576,7 +576,7 @@ rcloud.record.cell.execution <- function(user = .session$username, json.string) 
 #      file=pathConf("data.root", "history", "main_log.txt"), append=TRUE)
 }
 
-rcloud.debug.level <- function() if (hasConf("debug")) getConf("debug") else 0L
+rcloud.debug.level <- function() if (hasConf("debug")) as.integer(getConf("debug")) else 0L
 
 ################################################################################
 # stars


### PR DESCRIPTION
Hi @s-u, here is the RCloud part of att/rgithub#3.

I have tested
- old RCloud works fine with new rgithub and rcloud-gist-services
- this change works fine with github.com as the backend and does not include the `access_token` query parameter it was complaining about

I have not tested this change with rcloud-gist-services. 