### PR TITLE
download zig release version 0.14.0 by default

### DIFF
--- a/zig/download.sh
+++ b/zig/download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-ZIG_RELEASE_DEFAULT="0.13.0"
+ZIG_RELEASE_DEFAULT="0.14.0"
 # Default to the release build, or allow the latest dev build, or an explicit release version:
 ZIG_RELEASE=${1:-$ZIG_RELEASE_DEFAULT}
 if [ "$ZIG_RELEASE" = "latest" ]; then


### PR DESCRIPTION
Updates download.sh script to download Zig release version 0.14.0 if no argument is given.