### PR TITLE
docker fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -233,6 +233,10 @@ fn add_all_source_files(b: *Build, wf: *WriteFile, dirname: []const u8) void {
     _ = add_copy_file(b, wf, "build-aux/config.json", dirname);
     _ = add_copy_file(b, wf, "build-aux/generated/build.zig", dirname);
 
+    _ = add_copy_file(b, wf, "zig/download.sh", dirname);
+    _ = add_copy_file(b, wf, "zig/download.sh-README", dirname);
+    _ = add_copy_file(b, wf, "zig/download.sh-LICENSE", dirname);
+
     _ = add_copy_file(b, wf, "build.zig", dirname);
     _ = add_copy_file(b, wf, "build.zig.zon", dirname);
     _ = add_copy_file(b, wf, "flake.lock", dirname);

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -174,6 +174,9 @@ COPY LICENSE         .
 COPY package-lock.json .
 COPY package.json    .
 
+# Fetch MathJax
+RUN /bin/sh scripts/fetch-mathjax.sh
+
 # build
 RUN --mount=type=cache,target=/zig/global,sharing=locked \
     --mount=type=cache,target=/zig/local,sharing=locked \

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -145,10 +145,14 @@ FROM build-dep AS build
 WORKDIR /data/rcloud
 RUN chown -R rcloud:rcloud /data/rcloud
 
+# Copy download script
+COPY zig/download.sh         zig/download.sh
+COPY zig/download.sh-README  zig/download.sh-README
+COPY zig/download.sh-LICENSE zig/download.sh-LICENSE
+
 #
 # Download Zig 0.14.0
 #
-COPY zig/download.sh zig/download.sh
 RUN zig/download.sh 0.14.0
 
 # Add zig executable to path


### PR DESCRIPTION
This PR contains two fixes:

1. The `zig/download.sh` script was missing from the source tarball generation.
2. The Dockerfile now downloads MathJax using the `fetch-mathjax.sh` script as part of the build process.
