### PR TITLE
docker compose reproducibility improvements

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -224,12 +224,6 @@ fn add_all_source_files(b: *Build, wf: *WriteFile, dirname: []const u8) void {
     _ = add_copy_directory(b, wf, "services", dirname, options);
     _ = add_copy_directory(b, wf, "packages", dirname, options);
 
-    // add zig cache directory which includes the zig build dependency
-    // source files (not binaries). TODO: this path depends on the
-    // maintainer having properly built rcloud using the command `zig
-    // build --global-cache-dir zig/cache`
-    _ = add_copy_directory(b, wf, "zig/cache/p", dirname, options);
-
     _ = add_copy_file(b, wf, "build-aux/config.json", dirname);
     _ = add_copy_file(b, wf, "build-aux/generated/build.zig", dirname);
 
@@ -259,6 +253,12 @@ fn add_all_source_files_and_assets(b: *Build, wf: *WriteFile, dirname: []const u
 
     // include assets directory
     _ = add_copy_directory(b, wf, assets, dirname, options);
+
+    // add zig cache directory which includes the zig build dependency
+    // source files (not binaries). TODO: this path depends on the
+    // maintainer having properly built rcloud using the command `zig
+    // build --global-cache-dir zig/cache`
+    _ = add_copy_directory(b, wf, "zig/cache/p", dirname, options);
 
     // include generated javascript bundles. TODO: these paths depend
     // on the default install prefix, zig-out. It will fail otherwise.

--- a/conf/start2
+++ b/conf/start2
@@ -12,8 +12,9 @@ set -eo pipefail
 
 SCRIPT_DIR="$(realpath $(dirname "${BASH_SOURCE[0]}"))"
 export ROOT=$(realpath $SCRIPT_DIR/..)
-export R_LIBS=$(realpath $SCRIPT_DIR/../lib)
-export R_LIBS_USER=$R_LIBS
+
+: ${R_LIBS="$ROOT/lib"}
+export R_LIBS
 
 if [ "$1" = "-d" ]; then
    export DEBUG=1

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -33,7 +33,25 @@ ARG RCLOUD_RSERVE_PROXIFIED_CONF=docker/stage/rserve-proxified.conf
 # This is the RServe conf file for the single container runtime-simple
 # stage, used by the dev/ docker compose configuration. It is set in
 # docker/dev/compose.yaml.
-ARG RCLOUD_RSERVE_CONF=
+ARG RCLOUD_RSERVE_CONF
+
+#
+# Reproducibility
+#
+# Uncomment the following lines to increase the level of
+# reproducibility of this build of RCloud. These replace the default
+# apt package archive with a specific Debian snapshot, to ensure the
+# packages installed are identical. Without these changes, apt will
+# install the latest versions of packages. Using the snapshot
+# significantly increases the amount of time it takes to build this
+# Docker image until this layer is in the Docker build cache. See
+# https://snapshot.debian.org/ for more information.
+
+# RUN rm -f /etc/apt/sources.list.d/debian.sources &&                                                                                                                            \
+#     echo "deb     [check-valid-until=no] http://snapshot.debian.org/archive/debian/20241016T000000Z bookworm main" > /etc/apt/sources.list.d/debian.list &&                    \
+#     echo "deb     [check-valid-until=no] http://snapshot.debian.org/archive/debian/20241016T000000Z bookworm-updates main" >> /etc/apt/sources.list.d/debian.list &&           \
+#     echo "deb     [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20241016T000000Z bookworm-security main" >> /etc/apt/sources.list.d/debian.list
+
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked      \
     --mount=type=cache,target=/var/lib/apt,sharing=locked        \
@@ -41,8 +59,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked      \
     curl                                                         \
     git                                                          \
     locales                                                      \
-    wget                                                         \
-    && rm -rf /var/lib/apt/lists/*
+    wget
 
 # Make rcloud user
 RUN useradd -m rcloud
@@ -53,21 +70,21 @@ RUN useradd -m rcloud
 #
 FROM base AS build-dep
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked      \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked        \
-    apt-get update && apt-get install --no-install-recommends -y \
-    automake                                                     \
-    build-essential                                              \
-    libcairo2-dev                                                \
-    libcurl4-openssl-dev                                         \
-    libicu-dev                                                   \
-    libssl-dev                                                   \
-    pkg-config                                                   \
-    r-base                                                       \
-                                                                 \
-    nodejs                                                       \
-    npm                                                          \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get install --no-install-recommends -y              \
+    automake                                                \
+    build-essential                                         \
+    libcairo2-dev                                           \
+    libcurl4-openssl-dev                                    \
+    libicu-dev                                              \
+    libssl-dev                                              \
+    pkg-config                                              \
+    r-base                                                  \
+                                                            \
+    nodejs                                                  \
+    npm
+
 
 #
 # build-dep-java: this stage includes build dependencies for java, for
@@ -75,22 +92,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked      \
 #
 FROM base AS build-dep-java
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked      \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked        \
-    apt-get update && apt-get install --no-install-recommends -y \
-    build-essential                                              \
-    default-jdk                                                  \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get install --no-install-recommends -y              \
+    build-essential                                         \
+    default-jdk
+
 
 FROM build-dep-java AS dev-sks
 WORKDIR /data
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked      \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked        \
-    apt-get update && apt-get install --no-install-recommends -y \
-    libpam0g-dev                                                 \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get install --no-install-recommends -y              \
+    libpam0g-dev
 
+# TODO: Replace git clone with a reproducible build.
 RUN git clone --depth 1 https://github.com/s-u/SessionKeyServer.git && cd SessionKeyServer \
     && make -j${BUILD_JOBS}                                                                \
     && make -j${BUILD_JOBS} pam
@@ -128,7 +145,7 @@ ENV ROOT /data/rcloud
 # install runtime system dependencies for testing
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked   \
-    apt-get update && apt-get install -y                    \
+    apt-get install -y                                      \
     procps                                                  \
     redis-server
 
@@ -152,6 +169,9 @@ COPY zig/download.sh-LICENSE zig/download.sh-LICENSE
 
 #
 # Download Zig 0.14.0
+#
+# TODO: make this reproducible or at least verify the hash to protect
+# against supply chain attacks.
 #
 RUN zig/download.sh 0.14.0
 
@@ -178,13 +198,15 @@ COPY LICENSE         .
 COPY package-lock.json .
 COPY package.json    .
 
-# Fetch MathJax
-RUN /bin/sh scripts/fetch-mathjax.sh
+# Fetch MathJax.
+
+RUN --mount=type=cache,target=/data/rcloud/htdocs,sharing=locked \
+    /bin/sh scripts/fetch-mathjax.sh
 
 # build
-RUN --mount=type=cache,target=/zig/global,sharing=locked \
-    --mount=type=cache,target=/zig/local,sharing=locked \
-    zig build --cache-dir /zig/local --global-cache-dir /zig/global --summary new
+RUN --mount=type=cache,target=/data/rcloud/zig/cache,sharing=locked \
+    --mount=type=cache,target=/data/rcloud/.zig-cache,sharing=locked \
+    zig build --global-cache-dir /data/rcloud/zig/cache --summary new
 
 
 #
@@ -202,15 +224,15 @@ COPY README.md    .
 COPY NEWS.md      .
 COPY VERSION      .
 
-RUN --mount=type=cache,target=/zig/global,sharing=locked \
-    --mount=type=cache,target=/zig/local,sharing=locked \
-    zig build dist --cache-dir /zig/local --global-cache-dir /zig/global --summary new
+RUN --mount=type=cache,target=/data/rcloud/zig/cache,sharing=locked  \
+    --mount=type=cache,target=/data/rcloud/.zig-cache,sharing=locked \
+    zig build dist --global-cache-dir /data/rcloud/zig/cache --summary new
 
 FROM dist AS dist-fat
 WORKDIR /data/rcloud
-RUN --mount=type=cache,target=/zig/global,sharing=locked \
-    --mount=type=cache,target=/zig/local,sharing=locked \
-    zig build dist-fat -Dassets=zig-out/assets --cache-dir /zig/local --global-cache-dir /zig/global --summary new
+RUN --mount=type=cache,target=/data/rcloud/zig/cache,sharing=locked  \
+    --mount=type=cache,target=/data/rcloud/.zig-cache,sharing=locked \
+    zig build dist-fat -Dassets=zig-out/assets --global-cache-dir /data/rcloud/zig/cache --summary new
 
 
 
@@ -220,32 +242,43 @@ RUN --mount=type=cache,target=/zig/global,sharing=locked \
 # packages needed for runtime.
 #
 FROM base AS runtime
+
+# Additional system requirements to install when building the image.
+# Typically, to add packages that are required by user-installed R
+# packages.
+ARG RCLOUD_APT_INSTALL
+
 USER root
 WORKDIR /data/rcloud
 RUN chown -f rcloud:rcloud /data/rcloud
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && apt-get install -y \
-    dumb-init \
-    redis-server \
-    \
-    jupyter \
-    python3-ipython \
-    python3-ipykernel \
-    python3-nbconvert \
-    python3-nbformat \
-    python3-jupyter-client \
-    python3-jupyter-core \
-    \
-    r-base \
-    && rm -rf /var/lib/apt/lists/*
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get install -y                                      \
+    dumb-init                                               \
+    redis-server                                            \
+                                                            \
+    jupyter                                                 \
+    python3-ipython                                         \
+    python3-ipykernel                                       \
+    python3-nbconvert                                       \
+    python3-nbformat                                        \
+    python3-jupyter-client                                  \
+    python3-jupyter-core                                    \
+                                                            \
+    r-base
+
+# Install additional system dependencies, if any. Do not quote
+# $RCLOUD_APT_INSTALL.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked   \
+    apt-get install -y $RCLOUD_APT_INSTALL
 
 # Set locale: needed because rcloud won't run in C locale
 RUN echo "en_NZ.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
 ENV LANG=en_NZ.UTF-8
 
-# Copy build artifacts (zig-out)
+# Copy build artifacts from zig-out to root
 COPY --from=build --chown=rcloud:rcloud /data/rcloud/zig-out /data/rcloud/
 
 # Copy configuration files from build context.
@@ -264,9 +297,13 @@ ENV ROOT=/data/rcloud
 # Set R libs directories
 ENV R_LIBS=/data/rcloud/lib
 
+# Ensure RCloud lib directory is not user-writeable so that
+# user-installed packages don't go here.
+RUN chown root:root /data/rcloud/lib
+
 #
 # runtime-simple: the single-user local RCloud installation
-
+#
 FROM runtime AS runtime-simple
 WORKDIR /data/rcloud
 
@@ -284,6 +321,8 @@ RUN [ -f "$RCLOUD_RSERVE_CONF" ] && cp "$RCLOUD_RSERVE_CONF" conf/
 
 EXPOSE 8080
 USER rcloud
+
+
 
 ## WARNING: there is a potential race condition where redis may not be available before RCloud tests it -
 ## this is really just a toy setup

--- a/docker/common/Makefile
+++ b/docker/common/Makefile
@@ -1,77 +1,26 @@
 DOCKER_CONTEXT = ../..
 DEBIAN_DOCKERFILE = Dockerfile
-DEBIAN_TAG = rcloud-simple
-DOCKER_TARGET = runtime-simple
-HOST_PORT = 8080
-CONTAINER_PORT = 8080
-BUILD_JOBS = 16
 VERSION = $(shell cat $(DOCKER_CONTEXT)/VERSION)
 
 help:
 	@echo "This Makefile provides access and a reference to docker-related commands. Use the source, Luke."
 
-build:
-	@echo "Building..."
-	docker buildx build --build-arg BUILD_JOBS=$(BUILD_JOBS) -f $(DEBIAN_DOCKERFILE) --target $(DOCKER_TARGET) -t $(DEBIAN_TAG) $(DOCKER_CONTEXT)
-
-build-no-cache:
-	@echo "Building with --no-cache..."
-	docker buildx build --no-cache --build-arg BUILD_JOBS=$(BUILD_JOBS) -f $(DEBIAN_DOCKERFILE) --target $(DOCKER_TARGET) -t $(DEBIAN_TAG) $(DOCKER_CONTEXT)
-
-run:
-	@echo "Running ephemeral container..."
-	docker run -it --rm -p $(HOST_PORT):$(CONTAINER_PORT) \
-	--mount source=rcloud-run,target=/rcloud-run	      \
-	--mount source=rcloud-data,target=/rcloud-data	     \
-	--add-host=redis:127.0.0.1 $(DEBIAN_TAG)
-
-dev:
-	@echo "Building dev container..."
-	docker buildx build --build-arg BUILD_JOBS=$(BUILD_JOBS) -f $(DEBIAN_DOCKERFILE) --target dev -t runtime-dev $(DOCKER_CONTEXT)
-	@echo "Starting dev container..."
-	docker run -it --rm -p $(HOST_PORT):$(CONTAINER_PORT) \
-	-v "`pwd`:/src" \
-	--mount source=rcloud-run,target=/rcloud-run	      \
-	--mount source=rcloud-data,target=/rcloud-data	     \
-	--add-host=redis:127.0.0.1 --entrypoint /bin/bash runtime-dev
-
 dist:
 	@echo "Making source code distribution..."
-	docker buildx build --build-arg BUILD_JOBS=$(BUILD_JOBS) -f $(DEBIAN_DOCKERFILE) --target dist -t rcloud-dist $(DOCKER_CONTEXT)
+	docker buildx build -f $(DEBIAN_DOCKERFILE) --target dist -t rcloud-dist $(DOCKER_CONTEXT)
 	@echo "Copying tarball..."
 	docker create --name rcloud-cp-temp rcloud-dist                             \
 	&& docker cp rcloud-cp-temp:/data/rcloud/zig-out/rcloud-$(VERSION).tar.gz . \
-	&& docker rm rcloud-cp-temp
+	&& docker rm rcloud-cp-temp \
+	&& docker image rm rcloud-dist
 
 dist-fat:
 	@echo "Making fat source code distribution..."
-	docker buildx build --build-arg BUILD_JOBS=$(BUILD_JOBS) -f $(DEBIAN_DOCKERFILE) --target dist-fat -t rcloud-dist-fat $(DOCKER_CONTEXT)
+	docker buildx build -f $(DEBIAN_DOCKERFILE) --target dist-fat -t rcloud-dist-fat $(DOCKER_CONTEXT)
 	@echo "Copying tarball..."
 	docker create --name rcloud-cp-temp rcloud-dist-fat                         \
 	&& docker cp rcloud-cp-temp:/data/rcloud/zig-out/rcloud-full-$(VERSION).tar.gz . \
-	&& docker rm rcloud-cp-temp
+	&& docker rm rcloud-cp-temp \
+	&& docker image rm rcloud-dist-fat
 
-create:
-	@echo "Creating container..."
-	docker create -p $(HOST_PORT):$(CONTAINER_PORT) --name $(DEBIAN_TAG) $(DEBIAN_TAG)
-
-destroy:
-	@echo "DRY RUN: To destroy the container, run 'make destroy-no-dry-run'"
-
-destroy-no-dry-run:
-	@echo "Destroying container..."
-	docker container rm $(DEBIAN_TAG)
-
-start:
-	@echo "Starting container..."
-	docker start $(DEBIAN_TAG)
-
-stop:
-	@echo "Stopping container..."
-	docker stop $(DEBIAN_TAG)
-
-bash:
-	@echo "Connecting to running container..."
-	docker exec -it $(DEBIAN_TAG) bash
-
-.PHONY: bash build create destroy destroy-no-dry-run help run start stop
+.PHONY: help dist dist-fat

--- a/docker/common/backup.sh
+++ b/docker/common/backup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fname=rcloud-data.tar.gz
+volume=rcloud_rcloud-data
+
+if [ -e "$fname" ]; then
+    echo "$fname exists. Please move it out of the way."
+    exit 1
+fi
+
+# Shut down and remove containers. Preserves docker volumes.
+docker compose down
+
+# Create fresh containers (and volumes if necessary).
+docker compose create
+
+# Create tarball of volume mounted at /rcloud-data
+docker run --rm --mount "source=$volume,target=/rcloud-data" -v $(pwd):/backup busybox tar cvzf "/backup/$fname" /rcloud-data
+
+# Remove containers
+docker compose down

--- a/docker/common/build.sh
+++ b/docker/common/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+#
+# Initialises Dockerfile ARG RCLOUD_APT_INSTALL for additional system
+# packages to install in runtime images.
+#
+docker compose build --build-arg RCLOUD_APT_INSTALL="$(cat apt-install.txt)"

--- a/docker/common/restore.sh
+++ b/docker/common/restore.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+fname=rcloud-data.tar.gz
+volume=rcloud_rcloud-data
+
+if [ ! -e "$fname" ]; then
+    echo "$fname not found. Exiting."
+    exit 1
+fi
+
+nodryrun=''
+if [ x"$1" = "x--no-dry-run" ]; then
+    nodryrun=yes
+fi
+
+if [ -z "$nodryrun" ]; then
+    echo
+    echo "WARNING: this operation removes all data in the /rcloud-data volume."
+    echo "Pass --no-dry-run to perform the restore."
+    echo
+    echo "Listing all existing Docker volumes..."
+    echo
+    docker volume ls
+    echo
+    echo "Restore NOT PERFORMED. Exiting."
+    exit 1
+fi
+
+
+# Shut down and remove containers.
+docker compose down
+
+# Create fresh containers (and volumes if necessary).
+docker compose create
+
+# Unpack tarball into volume mounted at /rcloud-data
+if [ -n "$nodryrun" ]; then
+    docker run --rm --mount "source=$volume,target=/rcloud-data" -v $(pwd):/backup busybox sh -c "cd /rcloud-data && rm -rf * && tar xvf /backup/$fname --strip 1"
+fi
+
+# Remove containers
+docker compose down

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -19,3 +19,42 @@ To stop the containers, send a Control-C. To edit code and see the
 effects, save the edits, then perform `docker compose build` and
 `docker compose up` again. To clean up images (but not data), perform
 `docker compose down`.
+
+## RCloud notebook backup and restore
+
+When using this configuration, all RCloud notebook data is stored in a
+Docker volume called `rcloud_rcloud-data`. This volume may be backed
+up and restored using two provided scripts. `../common/backup.sh` will create
+the file `rcloud-data.tar.gz` containing the contents of the
+`rcloud_rcloud-data` volume.
+
+`../common/restore.sh` will read the file `rcloud-data.tar.gz` and **overwrite**
+the Docker volume on the current host containing all RCloud data.
+Because of its destructive nature, an additional argument
+`--no-dry-run` must be provided.
+
+## Additional system packages
+
+Additional system packages can be installed to the docker image by
+adding the Debian package names to the file `apt-install.txt`. This
+file is read by the `../common/build.sh` script and included as a build argument
+during `docker compose build`. It must contain at least one valid
+Debian package.
+
+The file `apt-install.txt` may be shared along with the
+`rcloud-data.tar.gz` file created as described in the previous
+section, to enable anyone to fully reproduce an RCloud installation.
+
+## Maintenance profile
+
+A maintenance profile is included in the docker compose configuration
+file `compose.yaml`. This may be used to access a bash command line
+in the container with the RCloud Docker volumes mounted. For example:
+
+```sh
+docker compose run --rm -v $(pwd):/mnt maint
+```
+
+will start an ephemeral container with the current directory mounted
+in the container at `/mnt`, and with access to the `rcloud-data`
+docker volume. This can be used to install data files, for example.

--- a/docker/dev/apt-install.txt
+++ b/docker/dev/apt-install.txt
@@ -1,0 +1,2 @@
+r-base-dev
+cmake

--- a/docker/dev/compose.yaml
+++ b/docker/dev/compose.yaml
@@ -16,6 +16,22 @@ services:
       - rcloud-data:/rcloud-data
       - rcloud-run:/rcloud-run
 
+  maint:
+    profiles:
+      - maint
+    image: rcloud-simple
+    entrypoint: /bin/bash
+    build:
+      context: ../..
+      dockerfile: docker/common/Dockerfile
+      target: runtime-simple
+      args:
+        - RCLOUD_CONF=docker/dev/rcloud.conf
+        - RCLOUD_RSERVE_CONF=docker/dev/rserve.conf
+    volumes:
+      - rcloud-data:/rcloud-data
+      - rcloud-run:/rcloud-run
+
 volumes:
   rcloud-run:
   rcloud-data:

--- a/docker/stage/README.md
+++ b/docker/stage/README.md
@@ -20,3 +20,28 @@ To stop the containers, send a Control-C. To edit code and see the
 effects, save the edits, then perform `docker compose build` and
 `docker compose up` again. To clean up images (but not data), perform
 `docker compose down`.
+
+## Additional system packages
+
+Additional system packages can be installed to the docker image by
+adding the Debian package names to the file `apt-install.txt`. This
+file is read by the `../common/build.sh` script and included as a build argument
+during `docker compose build`. It must contain at least one valid
+Debian package.
+
+The file `apt-install.txt` may be shared along with the
+`rcloud-data.tar.gz` file created as described in the previous
+section, to enable anyone to fully reproduce an RCloud installation.
+
+## RCloud notebook backup and restore
+
+When using this configuration, all RCloud notebook data is stored in a
+Docker volume called `rcloud_rcloud-data`. This volume may be backed
+up and restored using two provided scripts. `../common/backup.sh` will create
+the file `rcloud-data.tar.gz` containing the contents of the
+`rcloud_rcloud-data` volume.
+
+`../common/restore.sh` will read the file `rcloud-data.tar.gz` and **overwrite**
+the Docker volume on the current host containing all RCloud data.
+Because of its destructive nature, an additional argument
+`--no-dry-run` must be provided.

--- a/docker/stage/apt-install.txt
+++ b/docker/stage/apt-install.txt
@@ -1,0 +1,2 @@
+r-base-dev
+cmake


### PR DESCRIPTION
This is a squash commit of the following work:

- docker-based dist/dist-fat improvements:

  - build.zig: Remove zig/cache from source dist. It should only be included in fat source dist.

  - Makefile: Remove container and build related Makefile targets. Docker Compose configurations are preferred.

  - Dockerfile: Fix use of docker build cache for zig builds.

- add a maintenance target for docker compose:

  - This allows easy access to the docker volume which contains rcloud data, for maintenance purposes.

- use snapshot.debian.org to install debian packages reproducibly

- add build arg for additional packages to apt install:

  - This allows users to include additional system packages inside the RCloud Docker runtime images in order to support R packages that need them.

- build.sh: simple wrapper around `docker compose build` to set the build argument.

- apt-install.txt: contents will be read by build.sh and passed as a build argument to Docker.